### PR TITLE
Support multiple displays when positioning dialogs

### DIFF
--- a/scripts/mgear/maya/pyqt.py
+++ b/scripts/mgear/maya/pyqt.py
@@ -6,7 +6,7 @@
 import traceback
 import maya.OpenMayaUI as omui
 
-from mgear.vendor.Qt import QtWidgets, QtCompat
+from mgear.vendor.Qt import QtGui, QtWidgets, QtCompat
 
 # TODO: Delete after finish refactor
 # not used in this module, but imported in others
@@ -48,18 +48,21 @@ def showDialog(dialog, dInst=True, *args):
     # Create minimal dialog object
 
     # if versions.current() >= 20180000:
-    #     windw = dialog(maya_main_window())
+    #     window = dialog(maya_main_window())
     # else:
-    windw = dialog()
-    windw.move(QtWidgets.QApplication.desktop().screen().rect().center()
-               - windw.rect().center())
+    window = dialog()
+
+    cursor = QtGui.QCursor().pos()
+    window.move(
+        QtWidgets.QApplication.desktop().screenGeometry(cursor).center()
+        - window.rect().center())
 
     # Delete the UI if errors occur to avoid causing winEvent
     # and event errors (in Maya 2014)
     try:
-        windw.show()
+        window.show()
     except Exception:
-        windw.deleteLater()
+        window.deleteLater()
         traceback.print_exc()
 
 


### PR DESCRIPTION
When there are multiple displays, dialog windows are now placed in the center of the screen that currently contains the mouse pointer. This should resolve #223.