### PR TITLE
Synoptic: Make default synoptic tabs compatible with Python3

### DIFF
--- a/release/scripts/mgear/synoptic/tabs/__init__.py
+++ b/release/scripts/mgear/synoptic/tabs/__init__.py
@@ -222,11 +222,11 @@ class MainSynopticTab(QtWidgets.QDialog):
 
     def resetAll_clicked(self):
         # type: () -> None
-        print "resetAll"
+        print("resetAll")
 
     def resetSel_clicked(self):
         # type: () -> None
-        print "resetSel"
+        print("resetSel")
 
     def keyAll_clicked(self):
         # type: () -> None

--- a/release/scripts/mgear/synoptic/tabs/control_list/widget.py
+++ b/release/scripts/mgear/synoptic/tabs/control_list/widget.py
@@ -1,5 +1,5 @@
 import mgear.core.pyqt as gqt
-from searchControlsWidget import ControlListerUI
+from .searchControlsWidget import ControlListerUI
 
 QtGui, QtCore, QtWidgets, wrapInstance = gqt.qt_import()
 

--- a/release/scripts/mgear/synoptic/tabs/visibility/widget.py
+++ b/release/scripts/mgear/synoptic/tabs/visibility/widget.py
@@ -1,6 +1,6 @@
 
 import mgear.core.pyqt as gqt
-from toggleGeoVisibilityWidget import ToggleGeoVisibility
+from .toggleGeoVisibilityWidget import ToggleGeoVisibility
 
 QtGui, QtCore, QtWidgets, wrapInstance = gqt.qt_import()
 

--- a/release/scripts/mgear/synoptic/widgets.py
+++ b/release/scripts/mgear/synoptic/widgets.py
@@ -39,7 +39,7 @@ class toggleCombo(QtWidgets.QComboBox):
     def handleChanged(self):
         if self.firstUpdate:
             if self.currentIndex() == self.count() - 1:
-                print "Space Transfer"
+                print("Space Transfer")
                 self.setCurrentIndex(utils.getComboIndex(
                     self.model, self.uihost_name, self.combo_attr))
                 utils.ParentSpaceTransfer.showUI(self,


### PR DESCRIPTION
Sorry if this has been already solved, but i think this will fix the issue. #43 

- fix parentheses print function
- fix relative imports with dot notation

`visibility`, `quadruped`, `control_list`,  `baker`,  `biped` tabs are loaded as expected.

![Screenshot_408](https://user-images.githubusercontent.com/523673/131683530-6324cbd4-b97c-4ce8-aebc-27239770f0ac.png)
