### PR TITLE
key error on override guide color

### DIFF
--- a/release/scripts/mgear/shifter/component/__init__.py
+++ b/release/scripts/mgear/shifter/component/__init__.py
@@ -69,8 +69,8 @@ class Main(object):
                 self.color_fk = self.settings["RGB_fk"]
                 self.color_ik = self.settings["RGB_ik"]
             else:
-                self.color_fk = self.options["color_fk"]
-                self.color_ik = self.options["color_ik"]
+                self.color_fk = self.settings["color_fk"]
+                self.color_ik = self.settings["color_ik"]
         else:
             if self.options["Use_RGB_Color"]:
                 self.color_fk = self.options[self.side + "_RGB_fk"]


### PR DESCRIPTION
- color_fk key error when only selecting override colors on the guide settings. When used in combination with use RGB colors this worked fine.

![image](https://user-images.githubusercontent.com/31500795/138266863-b11fcdca-5a62-4ccb-890b-521021bb8f86.png)

- just updated to look for the correct settings