### PR TITLE
Add spring node gravity and simple collision

### DIFF
--- a/src/mgear_solvers.h
+++ b/src/mgear_solvers.h
@@ -533,11 +533,22 @@ public:
 	static MObject aGoalY;
 	static MObject aGoalZ;
 	static MObject aDamping;
+	static MObject aGravity;
 	static MObject aStiffness;
 	static MObject aTime;
+	static MObject aCollider;
+	static MObject aColliderX;
+	static MObject aColliderY;
+	static MObject aColliderZ;
+	static MObject aColliderRadius;
+	static MObject aColliderSoftness;
+	static MObject aColliderList;
 	//static MObject aParentInverse;
 	static MObject aSpringIntensity;
+	static MObject aSpringActive;
 
+	static MObject aUseGroundPlane;
+	static MObject aGroundPlaneHeight;
 	////variables
 
 	bool _initialized;

--- a/src/mgear_solvers.h
+++ b/src/mgear_solvers.h
@@ -515,11 +515,44 @@ public:
 
 };
 
+
 class mgear_springNode : public MPxNode
 {
 public:
-	mgear_springNode();
-	virtual			~mgear_springNode();
+    mgear_springNode();
+    virtual			~mgear_springNode();
+    virtual SchedulingType schedulingType() const;
+    static	void*	creator();
+
+    virtual MStatus		compute(const MPlug& plug, MDataBlock& data);
+    static MStatus		initialize();
+
+    static MTypeId id;
+    static MObject aOutput;
+    static MObject aGoal;
+    static MObject aGoalX;
+    static MObject aGoalY;
+    static MObject aGoalZ;
+    static MObject aDamping;
+    static MObject aStiffness;
+    static MObject aTime;
+    //static MObject aParentInverse;
+    static MObject aSpringIntensity;
+
+    ////variables
+
+    bool _initialized;
+    MTime _previousTime;
+    MFloatVector _currentPosition;
+    MFloatVector _previousPosition;
+
+};
+
+class mgear_springGravityNode : public MPxNode
+{
+public:
+	mgear_springGravityNode();
+	virtual			~mgear_springGravityNode();
 	virtual SchedulingType schedulingType() const;
 	static	void*	creator();
 
@@ -528,12 +561,14 @@ public:
 
 	static MTypeId id;
 	static MObject aOutput;
+  // static MObject aDebugOutput;
 	static MObject aGoal;
 	static MObject aGoalX;
 	static MObject aGoalY;
 	static MObject aGoalZ;
 	static MObject aDamping;
 	static MObject aGravity;
+  static MObject aGravityDirection;
 	static MObject aStiffness;
 	static MObject aTime;
 	static MObject aCollider;
@@ -543,20 +578,21 @@ public:
 	static MObject aColliderRadius;
 	static MObject aColliderSoftness;
 	static MObject aColliderList;
-	//static MObject aParentInverse;
+  static MObject aUseGroundPlane;
+  static MObject aGroundPlaneTransform;
+
 	static MObject aSpringIntensity;
 	static MObject aSpringActive;
 
-	static MObject aUseGroundPlane;
-	static MObject aGroundPlaneHeight;
 	////variables
-
 	bool _initialized;
 	MTime _previousTime;
-	MFloatVector _currentPosition;
-	MFloatVector _previousPosition;
+	MPoint _currentPosition;
+	MPoint _previousPosition;
 
 };
+
+
 
 class mgear_rayCastPosition : public MPxNode
 {

--- a/src/mgear_solvers.h
+++ b/src/mgear_solvers.h
@@ -582,7 +582,6 @@ public:
   static MObject aGroundPlaneTransform;
 
 	static MObject aSpringIntensity;
-	static MObject aSpringActive;
 
 	////variables
 	bool _initialized;

--- a/src/register.cpp
+++ b/src/register.cpp
@@ -80,6 +80,9 @@ PLUGIN_EXPORT MStatus initializePlugin( MObject obj )
 	status = plugin.registerNode("mgear_springNode", mgear_springNode::id, mgear_springNode::creator, mgear_springNode::initialize);
 		if (!status) { status.perror("registerNode() failed."); return status; }
 
+  status = plugin.registerNode("mgear_springGravityNode", mgear_springGravityNode::id, mgear_springGravityNode::creator, mgear_springGravityNode::initialize);
+		if (!status) { status.perror("registerNode() failed."); return status; }
+
 	status = plugin.registerNode("mgear_linearInterpolate3DvectorNode", mgear_linearInterpolate3DvectorNode::id, mgear_linearInterpolate3DvectorNode::creator, mgear_linearInterpolate3DvectorNode::initialize);
 		if (!status) { status.perror("registerNode() failed."); return status; }
 

--- a/src/springGravityNode.cpp
+++ b/src/springGravityNode.cpp
@@ -1,0 +1,350 @@
+/*
+
+MGEAR is under the terms of the MIT License
+
+Copyright (c) 2016 Jeremie Passerin, Miquel Campos
+Copyright (c) 2022 Michael Abrahams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Author:     Jeremie Passerin      geerem@hotmail.com  www.jeremiepasserin.com
+Author:     Miquel Campos         hello@miquel-campos.com  www.miquel-campos.com
+Date:       2016 / 10 / 10
+
+*/
+
+/////////////////////////////////////////////////
+// INCLUDE
+/////////////////////////////////////////////////
+#include "mgear_solvers.h"
+#include <maya/MFnCompoundAttribute.h>
+#include <maya/MArrayDataHandle.h>
+#include <maya/MArrayDataBuilder.h>
+
+/////////////////////////////////////////////////
+// GLOBAL
+/////////////////////////////////////////////////
+MTypeId		mgear_springGravityNode::id(0xF011FEC1);
+
+//Static variables
+
+MObject mgear_springGravityNode::aOutput;
+// MObject mgear_springGravityNode::aDebugOutput;
+MObject mgear_springGravityNode::aGoal;
+MObject mgear_springGravityNode::aGoalX;
+MObject mgear_springGravityNode::aGoalY;
+MObject mgear_springGravityNode::aGoalZ;
+
+MObject mgear_springGravityNode::aDamping;
+MObject mgear_springGravityNode::aStiffness;
+MObject mgear_springGravityNode::aTime;
+
+MObject mgear_springGravityNode::aGravity;
+MObject mgear_springGravityNode::aGravityDirection;
+
+MObject mgear_springGravityNode::aCollider;
+MObject mgear_springGravityNode::aColliderX;
+MObject mgear_springGravityNode::aColliderY;
+MObject mgear_springGravityNode::aColliderZ;
+MObject mgear_springGravityNode::aColliderRadius;
+MObject mgear_springGravityNode::aColliderList;
+MObject mgear_springGravityNode::aColliderSoftness;
+
+MObject mgear_springGravityNode::aSpringIntensity;
+MObject mgear_springGravityNode::aSpringActive;
+
+MObject mgear_springGravityNode::aUseGroundPlane;
+MObject mgear_springGravityNode::aGroundPlaneTransform;
+
+
+
+mgear_springGravityNode::mgear_springGravityNode(){}
+mgear_springGravityNode::~mgear_springGravityNode(){}
+
+mgear_springGravityNode::SchedulingType mgear_springGravityNode::schedulingType() const
+{
+	return kParallel;
+}
+
+void* mgear_springGravityNode::creator()
+{
+	return new mgear_springGravityNode();
+}
+
+
+
+//INIT
+MStatus mgear_springGravityNode::initialize()
+{
+	MStatus status;
+	MFnNumericAttribute nAttr;
+	MFnUnitAttribute uAttr;
+	MFnMatrixAttribute mAttr;
+	MFnCompoundAttribute cmpAttr;
+
+
+	aOutput = nAttr.createPoint("output", "out"); // initializing attribute
+	nAttr.setWritable(false);
+	nAttr.setStorable(false);
+	nAttr.setReadable(true);
+	addAttribute(aOutput); // adding the attribute to the node
+
+	// aDebugOutput = nAttr.createPoint("debug_output", "debug");
+	// nAttr.setStorable(false);
+	// nAttr.setReadable(true);
+	// nAttr.setKeyable(true);
+	// addAttribute(aDebugOutput);
+
+	aGoal = nAttr.createPoint("goal", "goal");
+	aGoalX = nAttr.child(0);
+	aGoalY = nAttr.child(1);
+	aGoalZ = nAttr.child(2);
+	nAttr.setKeyable(true);
+	nAttr.setStorable(false);
+	addAttribute(aGoal);
+	attributeAffects(aGoal, aOutput);
+
+	aTime = uAttr.create("time", "time", MFnUnitAttribute::kTime, 0.0f);
+	addAttribute(aTime);
+	attributeAffects(aTime, aOutput);
+
+	aStiffness = nAttr.create("stiffness", "stiffness", MFnNumericData::kDouble, 1.0f);
+	nAttr.setKeyable(true);
+	nAttr.setMin(0.0f);
+	nAttr.setMax(1.0f);
+	addAttribute(aStiffness);
+	attributeAffects(aStiffness, aOutput);
+
+	aDamping = nAttr.create("damping", "damping", MFnNumericData::kDouble, 1.0f);
+	nAttr.setKeyable(true);
+	nAttr.setMin(0.0f);
+	nAttr.setMax(1.0f);
+	addAttribute(aDamping);
+	attributeAffects(aDamping, aOutput);
+
+	aSpringIntensity = nAttr.create("intensity", "intensity", MFnNumericData::kDouble, 1.0f);
+	nAttr.setKeyable(true);
+	nAttr.setMin(0.0f);
+	nAttr.setMax(1.0f);
+	addAttribute(aSpringIntensity);
+	attributeAffects(aSpringIntensity, aOutput);
+
+	aSpringActive = nAttr.create("active", "active", MFnNumericData::kDouble, 1.0f);
+	nAttr.setKeyable(true);
+	nAttr.setMin(0.0f);
+	nAttr.setMax(1.0f);
+	addAttribute(aSpringActive);
+	attributeAffects(aSpringActive, aOutput);
+
+	aGravity = nAttr.create("gravity", "gravity", MFnNumericData::kDouble, 0.0f);
+	nAttr.setKeyable(true);
+	nAttr.setMin(-10.0f);
+	nAttr.setMax(10.0f);
+	addAttribute(aGravity);
+	attributeAffects(aGravity, aOutput);
+
+	aGravityDirection = nAttr.createPoint("gravity_direction", "gravity_direction");
+  nAttr.setDefault(0.0f, -1.0f, 0.0f);
+	nAttr.setKeyable(true);
+	nAttr.setStorable(false);
+	addAttribute(aGravityDirection);
+	attributeAffects(aGravityDirection, aOutput);
+
+
+	aColliderSoftness = nAttr.create("collide_softness", "collide_softness", MFnNumericData::kDouble, 0.5f);
+	nAttr.setKeyable(true);
+	nAttr.setMin(0.0f);
+	nAttr.setMax(1.0f);
+	addAttribute(aColliderSoftness);
+	attributeAffects(aColliderSoftness, aOutput);
+
+	aUseGroundPlane = nAttr.create("use_ground", "use_ground", MFnNumericData::kBoolean, 0);
+	nAttr.setKeyable(true);
+	addAttribute(aUseGroundPlane);
+	attributeAffects(aUseGroundPlane, aOutput);
+
+	aGroundPlaneTransform = mAttr.create("ground_transform", "ground_transform");
+  mAttr.setStorable(true);
+  mAttr.setKeyable(true);
+  mAttr.setConnectable(true);
+  addAttribute(aGroundPlaneTransform);
+  attributeAffects(aGroundPlaneTransform, aOutput);
+
+	aCollider = nAttr.createPoint("collider", "collider");
+	aColliderX = nAttr.child(0);
+	aColliderY = nAttr.child(1);
+	aColliderZ = nAttr.child(2);
+	nAttr.setKeyable(true);
+ 	McheckErr(nAttr.setDisconnectBehavior(MFnAttribute::kDelete), "setDisconnectBehavior");
+	addAttribute(aCollider);
+	attributeAffects(aCollider, aOutput);
+
+
+	aColliderRadius = nAttr.create("collide_radius", "collide_radius", MFnNumericData::kDouble, 0.0f);
+	nAttr.setKeyable(true);
+	nAttr.setMin(-1000.0f);
+	nAttr.setMax(1000.0f);
+ 	McheckErr(nAttr.setDisconnectBehavior(MFnAttribute::kDelete), "setDisconnectBehavior");
+	addAttribute(aColliderRadius);
+	attributeAffects(aColliderRadius, aOutput);
+
+
+	aColliderList = cmpAttr.create("colliders_list", "colliders_list", &status);
+	cmpAttr.setArray(true);
+	cmpAttr.setKeyable(true);
+	McheckErr(cmpAttr.addChild(aCollider), "compoundAttr.addChild");
+	McheckErr(cmpAttr.addChild(aColliderRadius), "compoundAttr.addChild");
+ 	McheckErr(cmpAttr.setDisconnectBehavior(MFnAttribute::kDelete), "setDisconnectBehavior");
+ 	McheckErr(addAttribute(aColliderList), "addAttribute");
+	McheckErr(attributeAffects(aColliderList, aOutput), "attributeAffects");
+
+
+
+
+	// bool _initialized = false;
+
+	return MS::kSuccess;
+}
+
+// COMPUTE
+
+MStatus mgear_springGravityNode::compute(const MPlug& plug, MDataBlock& data)
+{
+	MStatus status;
+
+	if (plug != aOutput)
+	{
+		return MS::kUnknownParameter;
+	}
+
+
+
+	// getting inputs attributes
+	double damping = data.inputValue(aDamping, &status).asDouble();
+	double stiffness = data.inputValue(aStiffness, &status).asDouble();
+	double gravity = data.inputValue(aGravity, &status).asDouble();
+	MFloatVector gravityDirection = data.inputValue(aGravityDirection, &status).asFloatVector();
+
+	//MVector goal = data.inputValue(aGoal, &status).asVector();
+	MDataHandle h;
+	MVector goal;
+	h = data.inputValue(aGoal, &status);
+	McheckStatusAndReturnIt(status);
+	goal = h.asFloatVector();
+
+
+	MTime currentTime = data.inputValue(aTime, &status).asTime();
+	double springIntensity = data.inputValue(aSpringIntensity, &status).asDouble();
+	double springActive = data.inputValue(aSpringActive, &status).asDouble();
+
+
+	if (_initialized == false) {
+		// Initialize the point states
+		//MGlobal::displayInfo( "mc_spring: Initialize the point states" );
+		_previousPosition = goal;
+		_currentPosition = goal;
+		_previousTime = currentTime;
+		_initialized = true;
+		//return MS::kSuccess;
+	}
+	// Check if the timestep is just 1 frame since we want a stable simulation
+	double timeDifference = currentTime.value() - _previousTime.value();
+	if (timeDifference > 1.0 || timeDifference < 0.0) {
+		_initialized = false;
+		_previousPosition = goal;
+		_currentPosition = goal;
+		_previousTime = currentTime;
+		//MGlobal::displayInfo( "mc_spring: time checker, reset position" );
+		//return MS::kSuccess;
+	}
+
+	// computation
+	MVector velocity = (_currentPosition - _previousPosition) * (1.0 - damping);
+	MFloatVector newPosition = _currentPosition + velocity;
+	MVector goalForce = (goal - newPosition) * stiffness;
+	goalForce += (gravity * gravityDirection);
+	newPosition += goalForce;
+
+
+
+	// Apply collision
+	double colliderStrength = 1.0 - data.inputValue(aColliderSoftness, &status).asDouble();
+	MVector colliderPos;
+	MVector distFromCollider;
+	double colliderRadius;
+  double collideAmount;
+	MArrayDataHandle arrayHandle = data.inputArrayValue(aColliderList, &status);
+	McheckErr(status, "arrayHandle construction for aColliderList failed\n");
+	unsigned count = arrayHandle.elementCount();
+	for( unsigned i = 0; i < count; i++) {
+		arrayHandle.jumpToArrayElement(i);
+		h = arrayHandle.inputValue(&status);
+		McheckErr(status, "handle evaluation failed\n");
+		colliderPos = h.child(aCollider).asVector();
+		colliderRadius = h.child(aColliderRadius).asDouble();
+		distFromCollider = newPosition - colliderPos;
+		collideAmount = (colliderRadius - distFromCollider.length()) / distFromCollider.length() * colliderStrength;
+		collideAmount = collideAmount > 0 ? collideAmount : 0;   // Only push outward
+		newPosition += collideAmount * distFromCollider; // Move radially
+	}
+
+
+	MMatrix groundPlaneTransform = data.inputValue(aGroundPlaneTransform, &status).asMatrix();
+	MMatrix groundPlaneInv = groundPlaneTransform.inverse();
+  double groundPlaneHeight = groundPlaneTransform(4, 2);
+
+  // Collide with a general plane
+	bool useGroundPlane = data.inputValue(aUseGroundPlane, &status).asBool();
+  MPoint transformedPosition = newPosition;
+  transformedPosition *= groundPlaneInv;
+	double distFromGround = transformedPosition[1] - groundPlaneHeight;
+	collideAmount = -1.0f * distFromGround * colliderStrength;
+
+  if (useGroundPlane && (collideAmount > 0)) {
+      transformedPosition[1] += collideAmount;
+      transformedPosition *= groundPlaneTransform;
+      newPosition = transformedPosition;
+  }
+
+
+	// store the states for the next calculation
+	_previousPosition = _currentPosition;
+	_currentPosition = newPosition;
+	_previousTime = currentTime;
+
+	// multiply the position by the spring intensity
+	newPosition = goal + (((newPosition - goal) * springIntensity) * springActive);
+
+
+
+	MDataHandle hOutput = data.outputValue(aOutput, &status);
+	McheckStatusAndReturnIt(status);
+	hOutput.set(newPosition);
+
+  // Debug
+	// hOutput = data.outputValue(aDebugOutput, &status);
+	// McheckStatusAndReturnIt(status);
+	// hOutput.set(MFloatVector(transformedPosition));
+
+	hOutput.setClean();
+	data.setClean(plug);
+
+	return MS::kSuccess;
+
+}

--- a/src/springNode.cpp
+++ b/src/springNode.cpp
@@ -32,9 +32,6 @@ Date:       2016 / 10 / 10
 // INCLUDE
 /////////////////////////////////////////////////
 #include "mgear_solvers.h"
-#include <maya/MFnCompoundAttribute.h>
-#include <maya/MArrayDataHandle.h>
-#include <maya/MArrayDataBuilder.h>
 
 /////////////////////////////////////////////////
 // GLOBAL
@@ -52,22 +49,8 @@ MObject mgear_springNode::aGoalZ;
 MObject mgear_springNode::aDamping;
 MObject mgear_springNode::aStiffness;
 MObject mgear_springNode::aTime;
-
-MObject mgear_springNode::aGravity;
-
-MObject mgear_springNode::aCollider;
-MObject mgear_springNode::aColliderX;
-MObject mgear_springNode::aColliderY;
-MObject mgear_springNode::aColliderZ;
-MObject mgear_springNode::aColliderRadius;
-MObject mgear_springNode::aColliderList;
-MObject mgear_springNode::aColliderSoftness;
-MObject mgear_springNode::aUseGroundPlane;
-MObject mgear_springNode::aGroundPlaneHeight;
-
 //MObject mgear_springNode::aParentInverse;
 MObject mgear_springNode::aSpringIntensity;
-MObject mgear_springNode::aSpringActive;
 
 
 mgear_springNode::mgear_springNode(){}
@@ -92,8 +75,6 @@ MStatus mgear_springNode::initialize()
 	MFnNumericAttribute nAttr;
 	MFnUnitAttribute uAttr;
 	MFnMatrixAttribute mAttr;
-	MFnCompoundAttribute cmpAttr;
-
 
 	aOutput = nAttr.createPoint("output", "out"); // initializing attribute
 	nAttr.setWritable(false);
@@ -135,68 +116,6 @@ MStatus mgear_springNode::initialize()
 	addAttribute(aSpringIntensity);
 	attributeAffects(aSpringIntensity, aOutput);
 
-	aSpringActive = nAttr.create("active", "active", MFnNumericData::kFloat, 1.0f);
-	nAttr.setKeyable(true);
-	nAttr.setMin(0.0f);
-	nAttr.setMax(1.0f);
-	addAttribute(aSpringActive);
-	attributeAffects(aSpringActive, aOutput);
-
-	aGravity = nAttr.create("gravity", "gravity", MFnNumericData::kFloat, 0.0f);
-	nAttr.setKeyable(true);
-	nAttr.setMin(-1000.0f);
-	nAttr.setMax(1000.0f);
-	addAttribute(aGravity);
-	attributeAffects(aGravity, aOutput);
-
-	aColliderSoftness = nAttr.create("collide_softness", "collide_softness", MFnNumericData::kFloat, 0.5f);
-	nAttr.setKeyable(true);
-	nAttr.setMin(0.0f);
-	nAttr.setMax(1.0f);
-	addAttribute(aColliderSoftness);
-	attributeAffects(aColliderSoftness, aOutput);
-
-	aUseGroundPlane = nAttr.create("use_ground", "use_ground", MFnNumericData::kBoolean, 0);
-	nAttr.setKeyable(true);
-	addAttribute(aUseGroundPlane);
-	attributeAffects(aUseGroundPlane, aOutput);
-
-	aGroundPlaneHeight = nAttr.create("ground_height", "ground_height", MFnNumericData::kFloat, 0.0f);
-	nAttr.setKeyable(true);
-	addAttribute(aGroundPlaneHeight);
-	attributeAffects(aGroundPlaneHeight, aOutput);
-
-
-	aCollider = nAttr.createPoint("collider", "collider");
-	aColliderX = nAttr.child(0);
-	aColliderY = nAttr.child(1);
-	aColliderZ = nAttr.child(2);
-	nAttr.setKeyable(true);
- 	McheckErr(nAttr.setDisconnectBehavior(MFnAttribute::kDelete), "setDisconnectBehavior");
-	addAttribute(aCollider);
-	attributeAffects(aCollider, aOutput);
-
-
-	aColliderRadius = nAttr.create("collide_radius", "collide_radius", MFnNumericData::kFloat, 0.0f);
-	nAttr.setKeyable(true);
-	nAttr.setMin(-1000.0f);
-	nAttr.setMax(1000.0f);
- 	McheckErr(nAttr.setDisconnectBehavior(MFnAttribute::kDelete), "setDisconnectBehavior");
-	addAttribute(aColliderRadius);
-	attributeAffects(aColliderRadius, aOutput);
-
-
-	aColliderList = cmpAttr.create("colliders_list", "colliders_list", &status);
-	cmpAttr.setArray(true);
-	cmpAttr.setKeyable(true);
-	McheckErr(cmpAttr.addChild(aCollider), "compoundAttr.addChild");
-	McheckErr(cmpAttr.addChild(aColliderRadius), "compoundAttr.addChild");
- 	McheckErr(cmpAttr.setDisconnectBehavior(MFnAttribute::kDelete), "setDisconnectBehavior");
- 	McheckErr(addAttribute(aColliderList), "addAttribute");
-	McheckErr(attributeAffects(aColliderList, aOutput), "attributeAffects");
-
-
-
 	/*aParentInverse = mAttr.create("parentInverse", "parentInverse");
 	mAttr.setStorable(true);
 	mAttr.setKeyable(true);
@@ -225,7 +144,6 @@ MStatus mgear_springNode::compute(const MPlug& plug, MDataBlock& data)
 	// getting inputs attributes
 	float damping = data.inputValue(aDamping, &status).asFloat();
 	float stiffness = data.inputValue(aStiffness, &status).asFloat();
-	float gravity = data.inputValue(aGravity, &status).asFloat();
 
 	//MVector goal = data.inputValue(aGoal, &status).asVector();
 	MDataHandle h;
@@ -233,12 +151,14 @@ MStatus mgear_springNode::compute(const MPlug& plug, MDataBlock& data)
 	h = data.inputValue(aGoal, &status);
 	McheckStatusAndReturnIt(status);
 	goal = h.asFloatVector();
+	// float aGoalX = goal.x;
+	// float aGoalY = goal.y;
+	// float aGoalZ = goal.z;
 
 
 	MTime currentTime = data.inputValue(aTime, &status).asTime();
 	//MMatrix parentInverse = data.inputValue(aParentInverse, &status).asMatrix();
 	float springIntensity = data.inputValue(aSpringIntensity, &status).asFloat();
-	float springActive = data.inputValue(aSpringActive, &status).asFloat();
 
 
 	if (_initialized == false) {
@@ -265,41 +185,7 @@ MStatus mgear_springNode::compute(const MPlug& plug, MDataBlock& data)
 	MFloatVector velocity = (_currentPosition - _previousPosition) * (1.0 - damping);
 	MVector newPosition = _currentPosition + velocity;
 	MFloatVector goalForce = (goal - newPosition) * stiffness;
-	goalForce.y += gravity;
 	newPosition += goalForce;
-
-
-
-	// Apply collision
-	float colliderStrength = 1.0 - data.inputValue(aColliderSoftness, &status).asFloat();
-	MVector colliderPos;
-	MVector distFromCollider;
-	float colliderRadius;
-  float collideAmount;
-	MArrayDataHandle arrayHandle = data.inputArrayValue(aColliderList, &status);
-	McheckErr(status, "arrayHandle construction for aColliderList failed\n");
-	unsigned count = arrayHandle.elementCount();
-	for( int i = 0; i < count; i++) {
-		arrayHandle.jumpToArrayElement(i);
-		h = arrayHandle.inputValue(&status);
-		McheckErr(status, "handle evaluation failed\n");
-		colliderPos = h.child(aCollider).asFloatVector();
-		colliderRadius = h.child(aColliderRadius).asFloat();
-		distFromCollider = newPosition - colliderPos;
-		collideAmount = (colliderRadius - distFromCollider.length()) / distFromCollider.length() * colliderStrength;
-		collideAmount = collideAmount > 0 ? collideAmount : 0;   // Only push outward
-		newPosition += collideAmount * distFromCollider; // Move radially
-	}
-
-
-	bool useGroundPlane = data.inputValue(aUseGroundPlane, &status).asBool();
-	float groundPlaneHeight = data.inputValue(aGroundPlaneHeight, &status).asFloat();
-
-	float distFromGround = (newPosition[1] - groundPlaneHeight);
-	float collideAmount = -1.0f * distFromGround * colliderStrength;
-	collideAmount = collideAmount > 0 ? collideAmount : 0;
-	newPosition[1] += ((float)useGroundPlane) * collideAmount;
-
 
 	// store the states for the next calculation
 	_previousPosition = _currentPosition;
@@ -308,7 +194,7 @@ MStatus mgear_springNode::compute(const MPlug& plug, MDataBlock& data)
 
 	//multipply the position by the spring intensity
 	//calculamos depues de los states, para no afectarlos
-	newPosition = goal + (((newPosition - goal) * springIntensity) * springActive);
+	newPosition = goal + ((newPosition - goal) * springIntensity);
 
 	//Setting the output in local space
 	// esto lo hacemos depues de hacer el store de los states


### PR DESCRIPTION
Issue #58 

Gravity sets a target bias in the -y direction.

Add support for a ground plane collider and a list of spherical
colliders. The ground plane prevents the spring from crossing below y=0.

Spherical colliders repel the springs from a point in space.

To create a geometrical UI for the collider, create a NURBS sphere, connect its
world space position to the input position, and its world space scale to the
collider radius.

Collision can be given a softness value to create soft or hard collisions.
Zero softness prevents springs from crossing the barriers entirely.

