### PR TITLE
Sphinx auto doc setup

### DIFF
--- a/docs/source/animbitsModules.rst
+++ b/docs/source/animbitsModules.rst
@@ -12,8 +12,6 @@ Introduction
 
 Animbits is a animation commont library with tools and functions for the animators.
 
-
-
 Modules
 -------
 
@@ -25,3 +23,9 @@ Modules
    mgear.animbits.softTweaks
 
 
+.. toctree::
+   :maxdepth: 2
+
+   mgear/mgear.animbits
+   mgear/mgear.animbits.menu
+   mgear/mgear.animbits.softTweaks

--- a/docs/source/baseModules.rst
+++ b/docs/source/baseModules.rst
@@ -16,7 +16,7 @@ Base Modules
    mgear.core.menu
    mgear.core.meshNavigation
    mgear.core.node
-   mgear.core.pickWalk
+   mgear/core.pickWalk
    mgear.core.primitive
    mgear.core.pyqt
    mgear.core.skin
@@ -26,3 +26,27 @@ Base Modules
    mgear.core.vector
    mgear.core.widgets
 
+.. toctree::
+   :maxdepth: 2
+
+   mgear/mgear
+   mgear/mgear.core
+   mgear/mgear.core.applyop
+   mgear/mgear.core.attribute
+   mgear/mgear.core.curve
+   mgear/mgear.core.dag
+   mgear/mgear.core.fcurve
+   mgear/mgear.core.icon
+   mgear/mgear.core.log
+   mgear/mgear.core.menu
+   mgear/mgear.core.meshNavigation
+   mgear/mgear.core.node
+   mgear.mgear/core.pickWalk
+   mgear/mgear.core.primitive
+   mgear/mgear.core.pyqt
+   mgear/mgear.core.skin
+   mgear/mgear.core.string
+   mgear/mgear.core.transform
+   mgear/mgear.core.utils
+   mgear/mgear.core.vector
+   mgear/mgear.core.widgets

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,15 +12,17 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 # sys.path.insert(0, os.path.abspath('C:\\datawork\\repo\\mgear\\scripts'))
-sys.path.insert(0, os.path.abspath('../release/scripts'))
+# sys.path.insert(0, os.path.abspath('./../../release/scripts'))
+sys.path.append(os.path.abspath('./../../release/scripts'))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -49,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'mGear: Rigging Framework'
-copyright = u'2011-2018, Jeremie Passerin, Miquel Campos, 2018-2021 The mGear Dev Team'
+copyright = u'2011-2022, Jeremie Passerin, Miquel Campos, 2018-2022 The mGear Dev Team'
 author = u'The mGear Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -66,7 +68,7 @@ release = u'4.0.3'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -77,6 +79,9 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = []
+
+# Mock imports
+autodoc_mock_imports = ["maya", "pymel", "Qt", "PySide", "PySide2"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/framework.rst
+++ b/docs/source/framework.rst
@@ -11,9 +11,9 @@ Framework
 	simpleRigModules
 	synopticModules
 
+
 .. toctree::
 	:maxdepth: 0
 	:hidden:
 
 	modulesList
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ Welcome to mGear: Rigging Framework for Autodesk Maya
    framework
    solvers
    animbitsUserDocumentation
+   rigbitsUserDocumentation
    crankUserDocumentation
    shifterUserDocumentation
    shifterComponentReference
@@ -37,7 +38,6 @@ Welcome to mGear: Rigging Framework for Autodesk Maya
    FAQ
    releaseLog
    license
-
 
 Indices and tables
 ==================

--- a/docs/source/mgear/animbits/softTweaks.rst
+++ b/docs/source/mgear/animbits/softTweaks.rst
@@ -1,6 +1,0 @@
-mgear.animbits.softTweaks
-==============================
-
-.. automodule:: mgear.animbits.softTweaks
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/applyop.rst
+++ b/docs/source/mgear/core/applyop.rst
@@ -1,7 +1,0 @@
-mgear.core.applyop
-==================
-
-
-.. automodule:: mgear.core.applyop
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/attribute.rst
+++ b/docs/source/mgear/core/attribute.rst
@@ -1,8 +1,0 @@
-mgear.core.attribute
-=====================
-
-
-.. automodule:: mgear.core.attribute
-   	:members:
-	:undoc-members:
-

--- a/docs/source/mgear/core/core.rst
+++ b/docs/source/mgear/core/core.rst
@@ -1,6 +1,0 @@
-mgear.core
-==========
-
-.. automodule:: mgear.core
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/curve.rst
+++ b/docs/source/mgear/core/curve.rst
@@ -1,7 +1,0 @@
-mgear.core.curve
-==================
-
-
-.. automodule:: mgear.core.curve
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/dag.rst
+++ b/docs/source/mgear/core/dag.rst
@@ -1,7 +1,0 @@
-mgear.core.dag
-==================
-
-
-.. automodule:: mgear.core.dag
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/fcurve.rst
+++ b/docs/source/mgear/core/fcurve.rst
@@ -1,7 +1,0 @@
-mgear.core.fcurve
-==================
-
-
-.. automodule:: mgear.core.fcurve
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/icon.rst
+++ b/docs/source/mgear/core/icon.rst
@@ -1,7 +1,0 @@
-mgear.core.icon
-==================
-
-
-.. automodule:: mgear.core.icon
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/log.rst
+++ b/docs/source/mgear/core/log.rst
@@ -1,7 +1,0 @@
-mgear.core.log
-==================
-
-
-.. automodule:: mgear.core.log
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/meshNavigation.rst
+++ b/docs/source/mgear/core/meshNavigation.rst
@@ -1,7 +1,0 @@
-mgear.core.meshNavigation
-=========================
-
-
-.. automodule:: mgear.core.meshNavigation
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/node.rst
+++ b/docs/source/mgear/core/node.rst
@@ -1,7 +1,0 @@
-mgear.core.node
-==================
-
-
-.. automodule:: mgear.core.node
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/pickWalk.rst
+++ b/docs/source/mgear/core/pickWalk.rst
@@ -1,7 +1,0 @@
-mgear.core.pickWalk
-===================
-
-
-.. automodule:: mgear.core.pickWalk
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/primitive.rst
+++ b/docs/source/mgear/core/primitive.rst
@@ -1,7 +1,0 @@
-mgear.core.primitive
-=====================
-
-
-.. automodule:: mgear.core.primitive
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/pyqt.rst
+++ b/docs/source/mgear/core/pyqt.rst
@@ -1,7 +1,0 @@
-mgear.core.pyqt
-===================
-
-
-.. automodule:: mgear.core.pyqt
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/skin.rst
+++ b/docs/source/mgear/core/skin.rst
@@ -1,7 +1,0 @@
-mgear.core.skin
-==================
-
-
-.. automodule:: mgear.core.skin
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/string.rst
+++ b/docs/source/mgear/core/string.rst
@@ -1,7 +1,0 @@
-mgear.string
-=======================
-
-.. automodule:: mgear.string
-	:members:
-	:undoc-members:
-

--- a/docs/source/mgear/core/transform.rst
+++ b/docs/source/mgear/core/transform.rst
@@ -1,7 +1,0 @@
-mgear.core.transform
-====================
-
-
-.. automodule:: mgear.core.transform
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/utils.rst
+++ b/docs/source/mgear/core/utils.rst
@@ -1,7 +1,0 @@
-mgear.core.utils
-==================
-
-
-.. automodule:: mgear.core.utils
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/vector.rst
+++ b/docs/source/mgear/core/vector.rst
@@ -1,7 +1,0 @@
-mgear.core.vector
-==================
-
-
-.. automodule:: mgear.core.vector
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/core/widgets.rst
+++ b/docs/source/mgear/core/widgets.rst
@@ -1,7 +1,0 @@
-mgear.core.widgets
-===================
-
-
-.. automodule:: mgear.core.widgets
-   	:members:
-	:undoc-members:

--- a/docs/source/mgear/mgear.anim_picker.gui.rst
+++ b/docs/source/mgear/mgear.anim_picker.gui.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.gui module
+=============================
+
+.. automodule:: mgear.anim_picker.gui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.handlers.action_handlers.rst
+++ b/docs/source/mgear/mgear.anim_picker.handlers.action_handlers.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.handlers.action\_handlers module
+===================================================
+
+.. automodule:: mgear.anim_picker.handlers.action_handlers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.handlers.file_handlers.rst
+++ b/docs/source/mgear/mgear.anim_picker.handlers.file_handlers.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.handlers.file\_handlers module
+=================================================
+
+.. automodule:: mgear.anim_picker.handlers.file_handlers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.handlers.maya_handlers.rst
+++ b/docs/source/mgear/mgear.anim_picker.handlers.maya_handlers.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.handlers.maya\_handlers module
+=================================================
+
+.. automodule:: mgear.anim_picker.handlers.maya_handlers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.handlers.mode_handlers.rst
+++ b/docs/source/mgear/mgear.anim_picker.handlers.mode_handlers.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.handlers.mode\_handlers module
+=================================================
+
+.. automodule:: mgear.anim_picker.handlers.mode_handlers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.handlers.python_handlers.rst
+++ b/docs/source/mgear/mgear.anim_picker.handlers.python_handlers.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.handlers.python\_handlers module
+===================================================
+
+.. automodule:: mgear.anim_picker.handlers.python_handlers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.handlers.rst
+++ b/docs/source/mgear/mgear.anim_picker.handlers.rst
@@ -1,0 +1,22 @@
+mgear.anim\_picker.handlers package
+===================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.anim_picker.handlers.action_handlers
+   mgear.anim_picker.handlers.file_handlers
+   mgear.anim_picker.handlers.maya_handlers
+   mgear.anim_picker.handlers.mode_handlers
+   mgear.anim_picker.handlers.python_handlers
+
+Module contents
+---------------
+
+.. automodule:: mgear.anim_picker.handlers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.menu.rst
+++ b/docs/source/mgear/mgear.anim_picker.menu.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.menu module
+==============================
+
+.. automodule:: mgear.anim_picker.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.picker_node.rst
+++ b/docs/source/mgear/mgear.anim_picker.picker_node.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.picker\_node module
+======================================
+
+.. automodule:: mgear.anim_picker.picker_node
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.rst
+++ b/docs/source/mgear/mgear.anim_picker.rst
@@ -1,0 +1,30 @@
+mgear.anim\_picker package
+==========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.anim_picker.handlers
+   mgear.anim_picker.widgets
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.anim_picker.gui
+   mgear.anim_picker.menu
+   mgear.anim_picker.picker_node
+   mgear.anim_picker.version
+
+Module contents
+---------------
+
+.. automodule:: mgear.anim_picker
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.version.rst
+++ b/docs/source/mgear/mgear.anim_picker.version.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.version module
+=================================
+
+.. automodule:: mgear.anim_picker.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.widgets.basic.rst
+++ b/docs/source/mgear/mgear.anim_picker.widgets.basic.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.widgets.basic module
+=======================================
+
+.. automodule:: mgear.anim_picker.widgets.basic
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.widgets.overlay_widgets.rst
+++ b/docs/source/mgear/mgear.anim_picker.widgets.overlay_widgets.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.widgets.overlay\_widgets module
+==================================================
+
+.. automodule:: mgear.anim_picker.widgets.overlay_widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.widgets.picker_widgets.rst
+++ b/docs/source/mgear/mgear.anim_picker.widgets.picker_widgets.rst
@@ -1,0 +1,7 @@
+mgear.anim\_picker.widgets.picker\_widgets module
+=================================================
+
+.. automodule:: mgear.anim_picker.widgets.picker_widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.anim_picker.widgets.rst
+++ b/docs/source/mgear/mgear.anim_picker.widgets.rst
@@ -1,0 +1,20 @@
+mgear.anim\_picker.widgets package
+==================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.anim_picker.widgets.basic
+   mgear.anim_picker.widgets.overlay_widgets
+   mgear.anim_picker.widgets.picker_widgets
+
+Module contents
+---------------
+
+.. automodule:: mgear.anim_picker.widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.cache_manager.collapse_widget.rst
+++ b/docs/source/mgear/mgear.animbits.cache_manager.collapse_widget.rst
@@ -1,0 +1,7 @@
+mgear.animbits.cache\_manager.collapse\_widget module
+=====================================================
+
+.. automodule:: mgear.animbits.cache_manager.collapse_widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.cache_manager.dialog.rst
+++ b/docs/source/mgear/mgear.animbits.cache_manager.dialog.rst
@@ -1,0 +1,7 @@
+mgear.animbits.cache\_manager.dialog module
+===========================================
+
+.. automodule:: mgear.animbits.cache_manager.dialog
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.cache_manager.mayautils.rst
+++ b/docs/source/mgear/mgear.animbits.cache_manager.mayautils.rst
@@ -1,0 +1,7 @@
+mgear.animbits.cache\_manager.mayautils module
+==============================================
+
+.. automodule:: mgear.animbits.cache_manager.mayautils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.cache_manager.model.rst
+++ b/docs/source/mgear/mgear.animbits.cache_manager.model.rst
@@ -1,0 +1,7 @@
+mgear.animbits.cache\_manager.model module
+==========================================
+
+.. automodule:: mgear.animbits.cache_manager.model
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.cache_manager.query.rst
+++ b/docs/source/mgear/mgear.animbits.cache_manager.query.rst
@@ -1,0 +1,7 @@
+mgear.animbits.cache\_manager.query module
+==========================================
+
+.. automodule:: mgear.animbits.cache_manager.query
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.cache_manager.rst
+++ b/docs/source/mgear/mgear.animbits.cache_manager.rst
@@ -1,0 +1,22 @@
+mgear.animbits.cache\_manager package
+=====================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.animbits.cache_manager.collapse_widget
+   mgear.animbits.cache_manager.dialog
+   mgear.animbits.cache_manager.mayautils
+   mgear.animbits.cache_manager.model
+   mgear.animbits.cache_manager.query
+
+Module contents
+---------------
+
+.. automodule:: mgear.animbits.cache_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.channel_master.rst
+++ b/docs/source/mgear/mgear.animbits.channel_master.rst
@@ -1,0 +1,7 @@
+mgear.animbits.channel\_master module
+=====================================
+
+.. automodule:: mgear.animbits.channel_master
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.channel_master_node.rst
+++ b/docs/source/mgear/mgear.animbits.channel_master_node.rst
@@ -1,0 +1,7 @@
+mgear.animbits.channel\_master\_node module
+===========================================
+
+.. automodule:: mgear.animbits.channel_master_node
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.channel_master_utils.rst
+++ b/docs/source/mgear/mgear.animbits.channel_master_utils.rst
@@ -1,0 +1,7 @@
+mgear.animbits.channel\_master\_utils module
+============================================
+
+.. automodule:: mgear.animbits.channel_master_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.channel_master_widgets.rst
+++ b/docs/source/mgear/mgear.animbits.channel_master_widgets.rst
@@ -1,0 +1,7 @@
+mgear.animbits.channel\_master\_widgets module
+==============================================
+
+.. automodule:: mgear.animbits.channel_master_widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.menu.rst
+++ b/docs/source/mgear/mgear.animbits.menu.rst
@@ -1,0 +1,7 @@
+mgear.animbits.menu module
+==========================
+
+.. automodule:: mgear.animbits.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.rst
+++ b/docs/source/mgear/mgear.animbits.rst
@@ -1,0 +1,34 @@
+mgear.animbits package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.animbits.cache_manager
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.animbits.channel_master
+   mgear.animbits.channel_master_node
+   mgear.animbits.channel_master_utils
+   mgear.animbits.channel_master_widgets
+   mgear.animbits.menu
+   mgear.animbits.softTweakWindowUI
+   mgear.animbits.softTweaks
+   mgear.animbits.space_recorder
+   mgear.animbits.version
+
+Module contents
+---------------
+
+.. automodule:: mgear.animbits
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.softTweakWindowUI.rst
+++ b/docs/source/mgear/mgear.animbits.softTweakWindowUI.rst
@@ -1,0 +1,7 @@
+mgear.animbits.softTweakWindowUI module
+=======================================
+
+.. automodule:: mgear.animbits.softTweakWindowUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.softTweaks.rst
+++ b/docs/source/mgear/mgear.animbits.softTweaks.rst
@@ -1,0 +1,7 @@
+mgear.animbits.softTweaks module
+================================
+
+.. automodule:: mgear.animbits.softTweaks
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.space_recorder.rst
+++ b/docs/source/mgear/mgear.animbits.space_recorder.rst
@@ -1,0 +1,7 @@
+mgear.animbits.space\_recorder module
+=====================================
+
+.. automodule:: mgear.animbits.space_recorder
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.animbits.version.rst
+++ b/docs/source/mgear/mgear.animbits.version.rst
@@ -1,0 +1,7 @@
+mgear.animbits.version module
+=============================
+
+.. automodule:: mgear.animbits.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.menu.rst
+++ b/docs/source/mgear/mgear.cfxbits.menu.rst
@@ -1,0 +1,7 @@
+mgear.cfxbits.menu module
+=========================
+
+.. automodule:: mgear.cfxbits.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.rst
+++ b/docs/source/mgear/mgear.cfxbits.rst
@@ -1,0 +1,27 @@
+mgear.cfxbits package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.cfxbits.xgenboost
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.cfxbits.menu
+   mgear.cfxbits.version
+
+Module contents
+---------------
+
+.. automodule:: mgear.cfxbits
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.version.rst
+++ b/docs/source/mgear/mgear.cfxbits.version.rst
@@ -1,0 +1,7 @@
+mgear.cfxbits.version module
+============================
+
+.. automodule:: mgear.cfxbits.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.xgenboost.guide.rst
+++ b/docs/source/mgear/mgear.cfxbits.xgenboost.guide.rst
@@ -1,0 +1,7 @@
+mgear.cfxbits.xgenboost.guide module
+====================================
+
+.. automodule:: mgear.cfxbits.xgenboost.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.xgenboost.rst
+++ b/docs/source/mgear/mgear.cfxbits.xgenboost.rst
@@ -1,0 +1,21 @@
+mgear.cfxbits.xgenboost package
+===============================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.cfxbits.xgenboost.guide
+   mgear.cfxbits.xgenboost.ui
+   mgear.cfxbits.xgenboost.ui_form
+   mgear.cfxbits.xgenboost.xgen_handler
+
+Module contents
+---------------
+
+.. automodule:: mgear.cfxbits.xgenboost
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.xgenboost.ui.rst
+++ b/docs/source/mgear/mgear.cfxbits.xgenboost.ui.rst
@@ -1,0 +1,7 @@
+mgear.cfxbits.xgenboost.ui module
+=================================
+
+.. automodule:: mgear.cfxbits.xgenboost.ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.xgenboost.ui_form.rst
+++ b/docs/source/mgear/mgear.cfxbits.xgenboost.ui_form.rst
@@ -1,0 +1,7 @@
+mgear.cfxbits.xgenboost.ui\_form module
+=======================================
+
+.. automodule:: mgear.cfxbits.xgenboost.ui_form
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.cfxbits.xgenboost.xgen_handler.rst
+++ b/docs/source/mgear/mgear.cfxbits.xgenboost.xgen_handler.rst
@@ -1,0 +1,7 @@
+mgear.cfxbits.xgenboost.xgen\_handler module
+============================================
+
+.. automodule:: mgear.cfxbits.xgenboost.xgen_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.anim_utils.rst
+++ b/docs/source/mgear/mgear.core.anim_utils.rst
@@ -1,0 +1,7 @@
+mgear.core.anim\_utils module
+=============================
+
+.. automodule:: mgear.core.anim_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.applyop.rst
+++ b/docs/source/mgear/mgear.core.applyop.rst
@@ -1,0 +1,7 @@
+mgear.core.applyop module
+=========================
+
+.. automodule:: mgear.core.applyop
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.attribute.rst
+++ b/docs/source/mgear/mgear.core.attribute.rst
@@ -1,0 +1,7 @@
+mgear.core.attribute module
+===========================
+
+.. automodule:: mgear.core.attribute
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.callbackManager.rst
+++ b/docs/source/mgear/mgear.core.callbackManager.rst
@@ -1,0 +1,7 @@
+mgear.core.callbackManager module
+=================================
+
+.. automodule:: mgear.core.callbackManager
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.curve.rst
+++ b/docs/source/mgear/mgear.core.curve.rst
@@ -1,0 +1,7 @@
+mgear.core.curve module
+=======================
+
+.. automodule:: mgear.core.curve
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.dag.rst
+++ b/docs/source/mgear/mgear.core.dag.rst
@@ -1,0 +1,7 @@
+mgear.core.dag module
+=====================
+
+.. automodule:: mgear.core.dag
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.dagmenu.rst
+++ b/docs/source/mgear/mgear.core.dagmenu.rst
@@ -1,0 +1,7 @@
+mgear.core.dagmenu module
+=========================
+
+.. automodule:: mgear.core.dagmenu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.dragdrop.rst
+++ b/docs/source/mgear/mgear.core.dragdrop.rst
@@ -1,0 +1,7 @@
+mgear.core.dragdrop module
+==========================
+
+.. automodule:: mgear.core.dragdrop
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.fcurve.rst
+++ b/docs/source/mgear/mgear.core.fcurve.rst
@@ -1,0 +1,7 @@
+mgear.core.fcurve module
+========================
+
+.. automodule:: mgear.core.fcurve
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.icon.rst
+++ b/docs/source/mgear/mgear.core.icon.rst
@@ -1,0 +1,7 @@
+mgear.core.icon module
+======================
+
+.. automodule:: mgear.core.icon
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.log.rst
+++ b/docs/source/mgear/mgear.core.log.rst
@@ -1,0 +1,7 @@
+mgear.core.log module
+=====================
+
+.. automodule:: mgear.core.log
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.menu.rst
+++ b/docs/source/mgear/mgear.core.menu.rst
@@ -1,0 +1,7 @@
+mgear.core.menu module
+======================
+
+.. automodule:: mgear.core.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.meshNavigation.rst
+++ b/docs/source/mgear/mgear.core.meshNavigation.rst
@@ -1,0 +1,7 @@
+mgear.core.meshNavigation module
+================================
+
+.. automodule:: mgear.core.meshNavigation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.node.rst
+++ b/docs/source/mgear/mgear.core.node.rst
@@ -1,0 +1,7 @@
+mgear.core.node module
+======================
+
+.. automodule:: mgear.core.node
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.pickWalk.rst
+++ b/docs/source/mgear/mgear.core.pickWalk.rst
@@ -1,0 +1,7 @@
+mgear.core.pickWalk module
+==========================
+
+.. automodule:: mgear.core.pickWalk
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.primitive.rst
+++ b/docs/source/mgear/mgear.core.primitive.rst
@@ -1,0 +1,7 @@
+mgear.core.primitive module
+===========================
+
+.. automodule:: mgear.core.primitive
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.pyFBX.rst
+++ b/docs/source/mgear/mgear.core.pyFBX.rst
@@ -1,0 +1,7 @@
+mgear.core.pyFBX module
+=======================
+
+.. automodule:: mgear.core.pyFBX
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.pyflow_widgets.rst
+++ b/docs/source/mgear/mgear.core.pyflow_widgets.rst
@@ -1,0 +1,7 @@
+mgear.core.pyflow\_widgets module
+=================================
+
+.. automodule:: mgear.core.pyflow_widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.pyqt.rst
+++ b/docs/source/mgear/mgear.core.pyqt.rst
@@ -1,0 +1,7 @@
+mgear.core.pyqt module
+======================
+
+.. automodule:: mgear.core.pyqt
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.rst
+++ b/docs/source/mgear/mgear.core.rst
@@ -1,0 +1,45 @@
+mgear.core package
+==================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.core.anim_utils
+   mgear.core.applyop
+   mgear.core.attribute
+   mgear.core.callbackManager
+   mgear.core.curve
+   mgear.core.dag
+   mgear.core.dagmenu
+   mgear.core.dragdrop
+   mgear.core.fcurve
+   mgear.core.icon
+   mgear.core.log
+   mgear.core.menu
+   mgear.core.meshNavigation
+   mgear.core.node
+   mgear.core.pickWalk
+   mgear.core.primitive
+   mgear.core.pyFBX
+   mgear.core.pyflow_widgets
+   mgear.core.pyqt
+   mgear.core.six
+   mgear.core.skin
+   mgear.core.string
+   mgear.core.transform
+   mgear.core.utils
+   mgear.core.vector
+   mgear.core.version
+   mgear.core.widgets
+   mgear.core.wmap
+
+Module contents
+---------------
+
+.. automodule:: mgear.core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.six.rst
+++ b/docs/source/mgear/mgear.core.six.rst
@@ -1,0 +1,7 @@
+mgear.core.six module
+=====================
+
+.. automodule:: mgear.core.six
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.skin.rst
+++ b/docs/source/mgear/mgear.core.skin.rst
@@ -1,0 +1,7 @@
+mgear.core.skin module
+======================
+
+.. automodule:: mgear.core.skin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.string.rst
+++ b/docs/source/mgear/mgear.core.string.rst
@@ -1,0 +1,7 @@
+mgear.core.string module
+========================
+
+.. automodule:: mgear.core.string
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.transform.rst
+++ b/docs/source/mgear/mgear.core.transform.rst
@@ -1,0 +1,7 @@
+mgear.core.transform module
+===========================
+
+.. automodule:: mgear.core.transform
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.utils.rst
+++ b/docs/source/mgear/mgear.core.utils.rst
@@ -1,0 +1,7 @@
+mgear.core.utils module
+=======================
+
+.. automodule:: mgear.core.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.vector.rst
+++ b/docs/source/mgear/mgear.core.vector.rst
@@ -1,0 +1,7 @@
+mgear.core.vector module
+========================
+
+.. automodule:: mgear.core.vector
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.version.rst
+++ b/docs/source/mgear/mgear.core.version.rst
@@ -1,0 +1,7 @@
+mgear.core.version module
+=========================
+
+.. automodule:: mgear.core.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.widgets.rst
+++ b/docs/source/mgear/mgear.core.widgets.rst
@@ -1,0 +1,7 @@
+mgear.core.widgets module
+=========================
+
+.. automodule:: mgear.core.widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.core.wmap.rst
+++ b/docs/source/mgear/mgear.core.wmap.rst
@@ -1,0 +1,7 @@
+mgear.core.wmap module
+======================
+
+.. automodule:: mgear.core.wmap
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.crank.crank_tool.rst
+++ b/docs/source/mgear/mgear.crank.crank_tool.rst
@@ -1,0 +1,7 @@
+mgear.crank.crank\_tool module
+==============================
+
+.. automodule:: mgear.crank.crank_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.crank.crank_ui.rst
+++ b/docs/source/mgear/mgear.crank.crank_ui.rst
@@ -1,0 +1,7 @@
+mgear.crank.crank\_ui module
+============================
+
+.. automodule:: mgear.crank.crank_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.crank.menu.rst
+++ b/docs/source/mgear/mgear.crank.menu.rst
@@ -1,0 +1,7 @@
+mgear.crank.menu module
+=======================
+
+.. automodule:: mgear.crank.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.crank.rst
+++ b/docs/source/mgear/mgear.crank.rst
@@ -1,0 +1,21 @@
+mgear.crank package
+===================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.crank.crank_tool
+   mgear.crank.crank_ui
+   mgear.crank.menu
+   mgear.crank.version
+
+Module contents
+---------------
+
+.. automodule:: mgear.crank
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.crank.version.rst
+++ b/docs/source/mgear/mgear.crank.version.rst
@@ -1,0 +1,7 @@
+mgear.crank.version module
+==========================
+
+.. automodule:: mgear.crank.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.analyze.rst
+++ b/docs/source/mgear/mgear.flex.analyze.rst
@@ -1,0 +1,7 @@
+mgear.flex.analyze module
+=========================
+
+.. automodule:: mgear.flex.analyze
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.analyze_widget.rst
+++ b/docs/source/mgear/mgear.flex.analyze_widget.rst
@@ -1,0 +1,7 @@
+mgear.flex.analyze\_widget module
+=================================
+
+.. automodule:: mgear.flex.analyze_widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.attributes.rst
+++ b/docs/source/mgear/mgear.flex.attributes.rst
@@ -1,0 +1,7 @@
+mgear.flex.attributes module
+============================
+
+.. automodule:: mgear.flex.attributes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.colors.rst
+++ b/docs/source/mgear/mgear.flex.colors.rst
@@ -1,0 +1,7 @@
+mgear.flex.colors module
+========================
+
+.. automodule:: mgear.flex.colors
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.decorators.rst
+++ b/docs/source/mgear/mgear.flex.decorators.rst
@@ -1,0 +1,7 @@
+mgear.flex.decorators module
+============================
+
+.. automodule:: mgear.flex.decorators
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.flex.rst
+++ b/docs/source/mgear/mgear.flex.flex.rst
@@ -1,0 +1,7 @@
+mgear.flex.flex module
+======================
+
+.. automodule:: mgear.flex.flex
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.flex_widget.rst
+++ b/docs/source/mgear/mgear.flex.flex_widget.rst
@@ -1,0 +1,7 @@
+mgear.flex.flex\_widget module
+==============================
+
+.. automodule:: mgear.flex.flex_widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.menu.rst
+++ b/docs/source/mgear/mgear.flex.menu.rst
@@ -1,0 +1,7 @@
+mgear.flex.menu module
+======================
+
+.. automodule:: mgear.flex.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.query.rst
+++ b/docs/source/mgear/mgear.flex.query.rst
@@ -1,0 +1,7 @@
+mgear.flex.query module
+=======================
+
+.. automodule:: mgear.flex.query
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.rst
+++ b/docs/source/mgear/mgear.flex.rst
@@ -1,0 +1,29 @@
+mgear.flex package
+==================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.flex.analyze
+   mgear.flex.analyze_widget
+   mgear.flex.attributes
+   mgear.flex.colors
+   mgear.flex.decorators
+   mgear.flex.flex
+   mgear.flex.flex_widget
+   mgear.flex.menu
+   mgear.flex.query
+   mgear.flex.update
+   mgear.flex.update_utils
+   mgear.flex.version
+
+Module contents
+---------------
+
+.. automodule:: mgear.flex
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.update.rst
+++ b/docs/source/mgear/mgear.flex.update.rst
@@ -1,0 +1,7 @@
+mgear.flex.update module
+========================
+
+.. automodule:: mgear.flex.update
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.update_utils.rst
+++ b/docs/source/mgear/mgear.flex.update_utils.rst
@@ -1,0 +1,7 @@
+mgear.flex.update\_utils module
+===============================
+
+.. automodule:: mgear.flex.update_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.flex.version.rst
+++ b/docs/source/mgear/mgear.flex.version.rst
@@ -1,0 +1,7 @@
+mgear.flex.version module
+=========================
+
+.. automodule:: mgear.flex.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.menu.rst
+++ b/docs/source/mgear/mgear.menu.rst
@@ -1,0 +1,7 @@
+mgear.menu module
+=================
+
+.. automodule:: mgear.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.blendShapes.rst
+++ b/docs/source/mgear/mgear.rigbits.blendShapes.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.blendShapes module
+================================
+
+.. automodule:: mgear.rigbits.blendShapes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.channelWrangler.rst
+++ b/docs/source/mgear/mgear.rigbits.channelWrangler.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.channelWrangler module
+====================================
+
+.. automodule:: mgear.rigbits.channelWrangler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.channelWranglerUI.rst
+++ b/docs/source/mgear/mgear.rigbits.channelWranglerUI.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.channelWranglerUI module
+======================================
+
+.. automodule:: mgear.rigbits.channelWranglerUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.cycleTweaks.rst
+++ b/docs/source/mgear/mgear.rigbits.cycleTweaks.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.cycleTweaks module
+================================
+
+.. automodule:: mgear.rigbits.cycleTweaks
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger.brow_rigger.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger.brow_rigger.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger.brow\_rigger module
+================================================
+
+.. automodule:: mgear.rigbits.facial_rigger.brow_rigger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger.constraints.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger.constraints.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger.constraints module
+===============================================
+
+.. automodule:: mgear.rigbits.facial_rigger.constraints
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger.eye_rigger.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger.eye_rigger.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger.eye\_rigger module
+===============================================
+
+.. automodule:: mgear.rigbits.facial_rigger.eye_rigger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger.helpers.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger.helpers.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger.helpers module
+===========================================
+
+.. automodule:: mgear.rigbits.facial_rigger.helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger.lib.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger.lib.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger.lib module
+=======================================
+
+.. automodule:: mgear.rigbits.facial_rigger.lib
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger.lips_rigger.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger.lips_rigger.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger.lips\_rigger module
+================================================
+
+.. automodule:: mgear.rigbits.facial_rigger.lips_rigger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger.rst
@@ -1,0 +1,23 @@
+mgear.rigbits.facial\_rigger package
+====================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.rigbits.facial_rigger.brow_rigger
+   mgear.rigbits.facial_rigger.constraints
+   mgear.rigbits.facial_rigger.eye_rigger
+   mgear.rigbits.facial_rigger.helpers
+   mgear.rigbits.facial_rigger.lib
+   mgear.rigbits.facial_rigger.lips_rigger
+
+Module contents
+---------------
+
+.. automodule:: mgear.rigbits.facial_rigger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger2.eye_rigger.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger2.eye_rigger.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger2.eye\_rigger module
+================================================
+
+.. automodule:: mgear.rigbits.facial_rigger2.eye_rigger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger2.eye_riggerUI.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger2.eye_riggerUI.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger2.eye\_riggerUI module
+==================================================
+
+.. automodule:: mgear.rigbits.facial_rigger2.eye_riggerUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger2.helpers.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger2.helpers.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger2.helpers module
+============================================
+
+.. automodule:: mgear.rigbits.facial_rigger2.helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger2.lib.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger2.lib.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.facial\_rigger2.lib module
+========================================
+
+.. automodule:: mgear.rigbits.facial_rigger2.lib
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.facial_rigger2.rst
+++ b/docs/source/mgear/mgear.rigbits.facial_rigger2.rst
@@ -1,0 +1,21 @@
+mgear.rigbits.facial\_rigger2 package
+=====================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.rigbits.facial_rigger2.eye_rigger
+   mgear.rigbits.facial_rigger2.eye_riggerUI
+   mgear.rigbits.facial_rigger2.helpers
+   mgear.rigbits.facial_rigger2.lib
+
+Module contents
+---------------
+
+.. automodule:: mgear.rigbits.facial_rigger2
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.ghost.rst
+++ b/docs/source/mgear/mgear.rigbits.ghost.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.ghost module
+==========================
+
+.. automodule:: mgear.rigbits.ghost
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.menu.rst
+++ b/docs/source/mgear/mgear.rigbits.menu.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.menu module
+=========================
+
+.. automodule:: mgear.rigbits.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.mirror_controls.rst
+++ b/docs/source/mgear/mgear.rigbits.mirror_controls.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.mirror\_controls module
+=====================================
+
+.. automodule:: mgear.rigbits.mirror_controls
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.postSpring.rst
+++ b/docs/source/mgear/mgear.rigbits.postSpring.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.postSpring module
+===============================
+
+.. automodule:: mgear.rigbits.postSpring
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.proxySlicer.rst
+++ b/docs/source/mgear/mgear.rigbits.proxySlicer.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.proxySlicer module
+================================
+
+.. automodule:: mgear.rigbits.proxySlicer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.rbf_io.rst
+++ b/docs/source/mgear/mgear.rigbits.rbf_io.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.rbf\_io module
+============================
+
+.. automodule:: mgear.rigbits.rbf_io
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.rbf_manager_ui.rst
+++ b/docs/source/mgear/mgear.rigbits.rbf_manager_ui.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.rbf\_manager\_ui module
+=====================================
+
+.. automodule:: mgear.rigbits.rbf_manager_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.rbf_node.rst
+++ b/docs/source/mgear/mgear.rigbits.rbf_node.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.rbf\_node module
+==============================
+
+.. automodule:: mgear.rigbits.rbf_node
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.rivet.rst
+++ b/docs/source/mgear/mgear.rigbits.rivet.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.rivet module
+==========================
+
+.. automodule:: mgear.rigbits.rivet
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.rope.rst
+++ b/docs/source/mgear/mgear.rigbits.rope.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.rope module
+=========================
+
+.. automodule:: mgear.rigbits.rope
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.rst
+++ b/docs/source/mgear/mgear.rigbits.rst
@@ -1,0 +1,48 @@
+mgear.rigbits package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.rigbits.facial_rigger
+   mgear.rigbits.facial_rigger2
+   mgear.rigbits.sdk_manager
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.rigbits.blendShapes
+   mgear.rigbits.channelWrangler
+   mgear.rigbits.channelWranglerUI
+   mgear.rigbits.cycleTweaks
+   mgear.rigbits.ghost
+   mgear.rigbits.menu
+   mgear.rigbits.mirror_controls
+   mgear.rigbits.postSpring
+   mgear.rigbits.proxySlicer
+   mgear.rigbits.rbf_io
+   mgear.rigbits.rbf_manager_ui
+   mgear.rigbits.rbf_node
+   mgear.rigbits.rivet
+   mgear.rigbits.rope
+   mgear.rigbits.sdk_io
+   mgear.rigbits.six
+   mgear.rigbits.tweaks
+   mgear.rigbits.utils
+   mgear.rigbits.version
+   mgear.rigbits.weightNode_io
+   mgear.rigbits.widgets
+
+Module contents
+---------------
+
+.. automodule:: mgear.rigbits
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.sdk_io.rst
+++ b/docs/source/mgear/mgear.rigbits.sdk_io.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.sdk\_io module
+============================
+
+.. automodule:: mgear.rigbits.sdk_io
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.sdk_manager.SDK_manager_ui.rst
+++ b/docs/source/mgear/mgear.rigbits.sdk_manager.SDK_manager_ui.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.sdk\_manager.SDK\_manager\_ui module
+==================================================
+
+.. automodule:: mgear.rigbits.sdk_manager.SDK_manager_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.sdk_manager.SDK_transfer_ui.rst
+++ b/docs/source/mgear/mgear.rigbits.sdk_manager.SDK_transfer_ui.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.sdk\_manager.SDK\_transfer\_ui module
+===================================================
+
+.. automodule:: mgear.rigbits.sdk_manager.SDK_transfer_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.sdk_manager.core.rst
+++ b/docs/source/mgear/mgear.rigbits.sdk_manager.core.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.sdk\_manager.core module
+======================================
+
+.. automodule:: mgear.rigbits.sdk_manager.core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.sdk_manager.rst
+++ b/docs/source/mgear/mgear.rigbits.sdk_manager.rst
@@ -1,0 +1,20 @@
+mgear.rigbits.sdk\_manager package
+==================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.rigbits.sdk_manager.SDK_manager_ui
+   mgear.rigbits.sdk_manager.SDK_transfer_ui
+   mgear.rigbits.sdk_manager.core
+
+Module contents
+---------------
+
+.. automodule:: mgear.rigbits.sdk_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.six.rst
+++ b/docs/source/mgear/mgear.rigbits.six.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.six module
+========================
+
+.. automodule:: mgear.rigbits.six
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.tweaks.rst
+++ b/docs/source/mgear/mgear.rigbits.tweaks.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.tweaks module
+===========================
+
+.. automodule:: mgear.rigbits.tweaks
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.utils.rst
+++ b/docs/source/mgear/mgear.rigbits.utils.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.utils module
+==========================
+
+.. automodule:: mgear.rigbits.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.version.rst
+++ b/docs/source/mgear/mgear.rigbits.version.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.version module
+============================
+
+.. automodule:: mgear.rigbits.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.weightNode_io.rst
+++ b/docs/source/mgear/mgear.rigbits.weightNode_io.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.weightNode\_io module
+===================================
+
+.. automodule:: mgear.rigbits.weightNode_io
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rigbits.widgets.rst
+++ b/docs/source/mgear/mgear.rigbits.widgets.rst
@@ -1,0 +1,7 @@
+mgear.rigbits.widgets module
+============================
+
+.. automodule:: mgear.rigbits.widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.rst
+++ b/docs/source/mgear/mgear.rst
@@ -1,7 +1,39 @@
-mgear
-=======================
+mgear package
+=============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.anim_picker
+   mgear.animbits
+   mgear.cfxbits
+   mgear.core
+   mgear.crank
+   mgear.flex
+   mgear.rigbits
+   mgear.shifter
+   mgear.shifter_classic_components
+   mgear.shifter_epic_components
+   mgear.simpleRig
+   mgear.synoptic
+   mgear.vendor
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.menu
+   mgear.version
+
+Module contents
+---------------
 
 .. automodule:: mgear
-	:members:
-	:undoc-members:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.afg_tools.rst
+++ b/docs/source/mgear/mgear.shifter.afg_tools.rst
@@ -1,0 +1,7 @@
+mgear.shifter.afg\_tools module
+===============================
+
+.. automodule:: mgear.shifter.afg_tools
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.afg_tools_ui.rst
+++ b/docs/source/mgear/mgear.shifter.afg_tools_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.afg\_tools\_ui module
+===================================
+
+.. automodule:: mgear.shifter.afg_tools_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.component.chain_guide_initializer.rst
+++ b/docs/source/mgear/mgear.shifter.component.chain_guide_initializer.rst
@@ -1,0 +1,7 @@
+mgear.shifter.component.chain\_guide\_initializer module
+========================================================
+
+.. automodule:: mgear.shifter.component.chain_guide_initializer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.component.chain_guide_initializer_ui.rst
+++ b/docs/source/mgear/mgear.shifter.component.chain_guide_initializer_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.component.chain\_guide\_initializer\_ui module
+============================================================
+
+.. automodule:: mgear.shifter.component.chain_guide_initializer_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.component.guide.rst
+++ b/docs/source/mgear/mgear.shifter.component.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter.component.guide module
+====================================
+
+.. automodule:: mgear.shifter.component.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.component.joint_names_ui.rst
+++ b/docs/source/mgear/mgear.shifter.component.joint_names_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.component.joint\_names\_ui module
+===============================================
+
+.. automodule:: mgear.shifter.component.joint_names_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.component.main_settings_ui.rst
+++ b/docs/source/mgear/mgear.shifter.component.main_settings_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.component.main\_settings\_ui module
+=================================================
+
+.. automodule:: mgear.shifter.component.main_settings_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.component.rst
+++ b/docs/source/mgear/mgear.shifter.component.rst
@@ -1,0 +1,22 @@
+mgear.shifter.component package
+===============================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter.component.chain_guide_initializer
+   mgear.shifter.component.chain_guide_initializer_ui
+   mgear.shifter.component.guide
+   mgear.shifter.component.joint_names_ui
+   mgear.shifter.component.main_settings_ui
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter.component
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.custom_step.rst
+++ b/docs/source/mgear/mgear.shifter.custom_step.rst
@@ -1,0 +1,7 @@
+mgear.shifter.custom\_step module
+=================================
+
+.. automodule:: mgear.shifter.custom_step
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.custom_step_ui.rst
+++ b/docs/source/mgear/mgear.shifter.custom_step_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.custom\_step\_ui module
+=====================================
+
+.. automodule:: mgear.shifter.custom_step_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.game_tools_disconnect.rst
+++ b/docs/source/mgear/mgear.shifter.game_tools_disconnect.rst
@@ -1,0 +1,7 @@
+mgear.shifter.game\_tools\_disconnect module
+============================================
+
+.. automodule:: mgear.shifter.game_tools_disconnect
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.game_tools_disconnect_ui.rst
+++ b/docs/source/mgear/mgear.shifter.game_tools_disconnect_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.game\_tools\_disconnect\_ui module
+================================================
+
+.. automodule:: mgear.shifter.game_tools_disconnect_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.game_tools_fbx.rst
+++ b/docs/source/mgear/mgear.shifter.game_tools_fbx.rst
@@ -1,0 +1,7 @@
+mgear.shifter.game\_tools\_fbx module
+=====================================
+
+.. automodule:: mgear.shifter.game_tools_fbx
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.game_tools_fbx_utils.rst
+++ b/docs/source/mgear/mgear.shifter.game_tools_fbx_utils.rst
@@ -1,0 +1,7 @@
+mgear.shifter.game\_tools\_fbx\_utils module
+============================================
+
+.. automodule:: mgear.shifter.game_tools_fbx_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.game_tools_fbx_widgets.rst
+++ b/docs/source/mgear/mgear.shifter.game_tools_fbx_widgets.rst
@@ -1,0 +1,7 @@
+mgear.shifter.game\_tools\_fbx\_widgets module
+==============================================
+
+.. automodule:: mgear.shifter.game_tools_fbx_widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide.rst
+++ b/docs/source/mgear/mgear.shifter.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide module
+==========================
+
+.. automodule:: mgear.shifter.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_diff_ui.rst
+++ b/docs/source/mgear/mgear.shifter.guide_diff_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_diff\_ui module
+====================================
+
+.. automodule:: mgear.shifter.guide_diff_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_manager.rst
+++ b/docs/source/mgear/mgear.shifter.guide_manager.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_manager module
+===================================
+
+.. automodule:: mgear.shifter.guide_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_manager_component.rst
+++ b/docs/source/mgear/mgear.shifter.guide_manager_component.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_manager\_component module
+==============================================
+
+.. automodule:: mgear.shifter.guide_manager_component
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_manager_component_ui.rst
+++ b/docs/source/mgear/mgear.shifter.guide_manager_component_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_manager\_component\_ui module
+==================================================
+
+.. automodule:: mgear.shifter.guide_manager_component_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_manager_gui.rst
+++ b/docs/source/mgear/mgear.shifter.guide_manager_gui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_manager\_gui module
+========================================
+
+.. automodule:: mgear.shifter.guide_manager_gui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_template.rst
+++ b/docs/source/mgear/mgear.shifter.guide_template.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_template module
+====================================
+
+.. automodule:: mgear.shifter.guide_template
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_template_explorer.rst
+++ b/docs/source/mgear/mgear.shifter.guide_template_explorer.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_template\_explorer module
+==============================================
+
+.. automodule:: mgear.shifter.guide_template_explorer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_template_explorer_ui.rst
+++ b/docs/source/mgear/mgear.shifter.guide_template_explorer_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_template\_explorer\_ui module
+==================================================
+
+.. automodule:: mgear.shifter.guide_template_explorer_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.guide_ui.rst
+++ b/docs/source/mgear/mgear.shifter.guide_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.guide\_ui module
+==============================
+
+.. automodule:: mgear.shifter.guide_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.io.rst
+++ b/docs/source/mgear/mgear.shifter.io.rst
@@ -1,0 +1,7 @@
+mgear.shifter.io module
+=======================
+
+.. automodule:: mgear.shifter.io
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.menu.rst
+++ b/docs/source/mgear/mgear.shifter.menu.rst
@@ -1,0 +1,7 @@
+mgear.shifter.menu module
+=========================
+
+.. automodule:: mgear.shifter.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.mocap_tools.rst
+++ b/docs/source/mgear/mgear.shifter.mocap_tools.rst
@@ -1,0 +1,7 @@
+mgear.shifter.mocap\_tools module
+=================================
+
+.. automodule:: mgear.shifter.mocap_tools
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.naming.rst
+++ b/docs/source/mgear/mgear.shifter.naming.rst
@@ -1,0 +1,7 @@
+mgear.shifter.naming module
+===========================
+
+.. automodule:: mgear.shifter.naming
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.naming_rules_ui.rst
+++ b/docs/source/mgear/mgear.shifter.naming_rules_ui.rst
@@ -1,0 +1,7 @@
+mgear.shifter.naming\_rules\_ui module
+======================================
+
+.. automodule:: mgear.shifter.naming_rules_ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.plebes.rst
+++ b/docs/source/mgear/mgear.shifter.plebes.rst
@@ -1,0 +1,7 @@
+mgear.shifter.plebes module
+===========================
+
+.. automodule:: mgear.shifter.plebes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.relative_guide_placement.rst
+++ b/docs/source/mgear/mgear.shifter.relative_guide_placement.rst
@@ -1,0 +1,7 @@
+mgear.shifter.relative\_guide\_placement module
+===============================================
+
+.. automodule:: mgear.shifter.relative_guide_placement
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.rst
+++ b/docs/source/mgear/mgear.shifter.rst
@@ -1,0 +1,52 @@
+mgear.shifter package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter.component
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter.afg_tools
+   mgear.shifter.afg_tools_ui
+   mgear.shifter.custom_step
+   mgear.shifter.custom_step_ui
+   mgear.shifter.game_tools_disconnect
+   mgear.shifter.game_tools_disconnect_ui
+   mgear.shifter.game_tools_fbx
+   mgear.shifter.game_tools_fbx_utils
+   mgear.shifter.game_tools_fbx_widgets
+   mgear.shifter.guide
+   mgear.shifter.guide_diff_ui
+   mgear.shifter.guide_manager
+   mgear.shifter.guide_manager_component
+   mgear.shifter.guide_manager_component_ui
+   mgear.shifter.guide_manager_gui
+   mgear.shifter.guide_template
+   mgear.shifter.guide_template_explorer
+   mgear.shifter.guide_template_explorer_ui
+   mgear.shifter.guide_ui
+   mgear.shifter.io
+   mgear.shifter.menu
+   mgear.shifter.mocap_tools
+   mgear.shifter.naming
+   mgear.shifter.naming_rules_ui
+   mgear.shifter.plebes
+   mgear.shifter.relative_guide_placement
+   mgear.shifter.version
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter.version.rst
+++ b/docs/source/mgear/mgear.shifter.version.rst
@@ -1,0 +1,7 @@
+mgear.shifter.version module
+============================
+
+.. automodule:: mgear.shifter.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_01.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_01 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.arm_2jnt_01.guide
+   mgear.shifter_classic_components.arm_2jnt_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_01.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_02.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_02.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_02.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_02.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_02.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_02.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_02 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.arm_2jnt_02.guide
+   mgear.shifter_classic_components.arm_2jnt_02.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_02
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_02.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_02.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_02.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_02.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_03.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_03.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_03.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_03.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_03.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_03.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_03 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.arm_2jnt_03.guide
+   mgear.shifter_classic_components.arm_2jnt_03.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_03
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_03.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_03.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_03.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_03.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_04.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_04.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_04.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_04.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_04.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_04.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_04 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.arm_2jnt_04.guide
+   mgear.shifter_classic_components.arm_2jnt_04.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_04
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_04.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_04.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_04.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_04.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_freeTangents_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_freeTangents_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_freeTangents\_01.guide module
+===========================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_freeTangents_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_freeTangents_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_freeTangents_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_freeTangents\_01 package
+======================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.arm_2jnt_freeTangents_01.guide
+   mgear.shifter_classic_components.arm_2jnt_freeTangents_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_freeTangents_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_freeTangents_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_2jnt_freeTangents_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_2jnt\_freeTangents\_01.settingsUI module
+================================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_2jnt_freeTangents_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_ms_2jnt_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_ms_2jnt_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_ms\_2jnt\_01.guide module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_ms_2jnt_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_ms_2jnt_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_ms_2jnt_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.arm\_ms\_2jnt\_01 package
+============================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.arm_ms_2jnt_01.guide
+   mgear.shifter_classic_components.arm_ms_2jnt_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.arm_ms_2jnt_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.arm_ms_2jnt_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.arm_ms_2jnt_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.arm\_ms\_2jnt\_01.settingsUI module
+======================================================================
+
+.. automodule:: mgear.shifter_classic_components.arm_ms_2jnt_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.cable_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.cable_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.cable\_01.guide module
+=========================================================
+
+.. automodule:: mgear.shifter_classic_components.cable_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.cable_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.cable_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.cable\_01 package
+====================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.cable_01.guide
+   mgear.shifter_classic_components.cable_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.cable_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.cable_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.cable_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.cable\_01.settingsUI module
+==============================================================
+
+.. automodule:: mgear.shifter_classic_components.cable_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_01.guide module
+=========================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_01 package
+====================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_01.guide
+   mgear.shifter_classic_components.chain_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_01.settingsUI module
+==============================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_01.guide module
+=====================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_01 package
+================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_FK_spline_01.guide
+   mgear.shifter_classic_components.chain_FK_spline_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_01.settingsUI module
+==========================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_02.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_02.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_02.guide module
+=====================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_02.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_02.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_02.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_02 package
+================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_FK_spline_02.guide
+   mgear.shifter_classic_components.chain_FK_spline_02.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_02
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_02.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_02.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_02.settingsUI module
+==========================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_02.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_variable\_IK\_01.guide module
+===================================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_variable\_IK\_01 package
+==============================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.guide
+   mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_variable_IK_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_FK\_spline\_variable\_IK\_01.settingsUI module
+========================================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_FK_spline_variable_IK_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_IK\_spline\_variable\_FK\_01.guide module
+===================================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_IK\_spline\_variable\_FK\_01 package
+==============================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.guide
+   mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_IK_spline_variable_FK_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_IK\_spline\_variable\_FK\_01.settingsUI module
+========================================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_IK_spline_variable_FK_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_IK\_spline\_variable\_FK\_stack\_01.guide module
+==========================================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_IK\_spline\_variable\_FK\_stack\_01 package
+=====================================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.guide
+   mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_IK\_spline\_variable\_FK\_stack\_01.settingsUI module
+===============================================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_loc_ori_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_loc_ori_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_loc\_ori\_01.guide module
+===================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_loc_ori_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_loc_ori_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_loc_ori_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_loc\_ori\_01 package
+==============================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_loc_ori_01.guide
+   mgear.shifter_classic_components.chain_loc_ori_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_loc_ori_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_loc_ori_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_loc_ori_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_loc\_ori\_01.settingsUI module
+========================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_loc_ori_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_net_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_net_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_net\_01.guide module
+==============================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_net_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_net_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_net_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_net\_01 package
+=========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_net_01.guide
+   mgear.shifter_classic_components.chain_net_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_net_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_net_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_net_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_net\_01.settingsUI module
+===================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_net_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_spring_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_spring_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_spring\_01.guide module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_spring_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_spring_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_spring_01.rst
@@ -1,0 +1,18 @@
+mgear.shifter\_classic\_components.chain\_spring\_01 package
+============================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_spring_01.guide
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_spring_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_spring_lite_stack_master_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_spring_lite_stack_master_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_spring\_lite\_stack\_master\_01.guide module
+======================================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_spring_lite_stack_master_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_spring_lite_stack_master_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_spring_lite_stack_master_01.rst
@@ -1,0 +1,18 @@
+mgear.shifter\_classic\_components.chain\_spring\_lite\_stack\_master\_01 package
+=================================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_spring_lite_stack_master_01.guide
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_spring_lite_stack_master_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_stack_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_stack_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_stack\_01.guide module
+================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_stack_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_stack_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_stack_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_stack\_01 package
+===========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_stack_01.guide
+   mgear.shifter_classic_components.chain_stack_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_stack_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_stack_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_stack_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_stack\_01.settingsUI module
+=====================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_stack_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_whip_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_whip_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_whip\_01.guide module
+===============================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_whip_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_whip_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_whip_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.chain\_whip\_01 package
+==========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.chain_whip_01.guide
+   mgear.shifter_classic_components.chain_whip_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.chain_whip_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.chain_whip_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.chain_whip_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.chain\_whip\_01.settingsUI module
+====================================================================
+
+.. automodule:: mgear.shifter_classic_components.chain_whip_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.control_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.control_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.control\_01.guide module
+===========================================================
+
+.. automodule:: mgear.shifter_classic_components.control_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.control_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.control_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.control\_01 package
+======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.control_01.guide
+   mgear.shifter_classic_components.control_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.control_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.control_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.control_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.control\_01.settingsUI module
+================================================================
+
+.. automodule:: mgear.shifter_classic_components.control_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.eye_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.eye_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.eye\_01.guide module
+=======================================================
+
+.. automodule:: mgear.shifter_classic_components.eye_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.eye_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.eye_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.eye\_01 package
+==================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.eye_01.guide
+   mgear.shifter_classic_components.eye_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.eye_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.eye_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.eye_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.eye\_01.settingsUI module
+============================================================
+
+.. automodule:: mgear.shifter_classic_components.eye_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.foot_bk_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.foot_bk_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.foot\_bk\_01.guide module
+============================================================
+
+.. automodule:: mgear.shifter_classic_components.foot_bk_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.foot_bk_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.foot_bk_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.foot\_bk\_01 package
+=======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.foot_bk_01.guide
+   mgear.shifter_classic_components.foot_bk_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.foot_bk_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.foot_bk_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.foot_bk_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.foot\_bk\_01.settingsUI module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.foot_bk_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.hydraulic_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.hydraulic_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.hydraulic\_01.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.hydraulic_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.hydraulic_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.hydraulic_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.hydraulic\_01 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.hydraulic_01.guide
+   mgear.shifter_classic_components.hydraulic_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.hydraulic_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.hydraulic_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.hydraulic_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.hydraulic\_01.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.hydraulic_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_01.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_01 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.leg_2jnt_01.guide
+   mgear.shifter_classic_components.leg_2jnt_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_01.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_02.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_02.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_02.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_02.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_02.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_02.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_02 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.leg_2jnt_02.guide
+   mgear.shifter_classic_components.leg_2jnt_02.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_02
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_02.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_02.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_02.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_02.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_freeTangents_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_freeTangents_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_freeTangents\_01.guide module
+===========================================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_freeTangents_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_freeTangents_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_freeTangents_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_freeTangents\_01 package
+======================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.leg_2jnt_freeTangents_01.guide
+   mgear.shifter_classic_components.leg_2jnt_freeTangents_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_freeTangents_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_freeTangents_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_2jnt_freeTangents_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_2jnt\_freeTangents\_01.settingsUI module
+================================================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_2jnt_freeTangents_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_3jnt_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_3jnt_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_3jnt\_01.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_3jnt_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_3jnt_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_3jnt_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.leg\_3jnt\_01 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.leg_3jnt_01.guide
+   mgear.shifter_classic_components.leg_3jnt_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.leg_3jnt_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_3jnt_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_3jnt_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_3jnt\_01.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_3jnt_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_ms_2jnt_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_ms_2jnt_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_ms\_2jnt\_01.guide module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_ms_2jnt_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_ms_2jnt_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_ms_2jnt_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.leg\_ms\_2jnt\_01 package
+============================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.leg_ms_2jnt_01.guide
+   mgear.shifter_classic_components.leg_ms_2jnt_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.leg_ms_2jnt_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.leg_ms_2jnt_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.leg_ms_2jnt_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.leg\_ms\_2jnt\_01.settingsUI module
+======================================================================
+
+.. automodule:: mgear.shifter_classic_components.leg_ms_2jnt_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.lite\_chain\_01.guide module
+===============================================================
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.lite\_chain\_01 package
+==========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.lite_chain_01.guide
+   mgear.shifter_classic_components.lite_chain_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.lite\_chain\_01.settingsUI module
+====================================================================
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.lite\_chain\_stack\_01.guide module
+======================================================================
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_stack_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.lite\_chain\_stack\_01 package
+=================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.lite_chain_stack_01.guide
+   mgear.shifter_classic_components.lite_chain_stack_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_stack_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.lite\_chain\_stack\_01.settingsUI module
+===========================================================================
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_stack_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_02.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_02.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.lite\_chain\_stack\_02.guide module
+======================================================================
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_stack_02.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_02.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_02.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.lite\_chain\_stack\_02 package
+=================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.lite_chain_stack_02.guide
+   mgear.shifter_classic_components.lite_chain_stack_02.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_stack_02
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_02.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.lite_chain_stack_02.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.lite\_chain\_stack\_02.settingsUI module
+===========================================================================
+
+.. automodule:: mgear.shifter_classic_components.lite_chain_stack_02.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.meta_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.meta_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.meta\_01.guide module
+========================================================
+
+.. automodule:: mgear.shifter_classic_components.meta_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.meta_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.meta_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.meta\_01 package
+===================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.meta_01.guide
+   mgear.shifter_classic_components.meta_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.meta_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.meta_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.meta_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.meta\_01.settingsUI module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.meta_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.mouth_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.mouth_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.mouth\_01.guide module
+=========================================================
+
+.. automodule:: mgear.shifter_classic_components.mouth_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.mouth_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.mouth_01.rst
@@ -1,0 +1,18 @@
+mgear.shifter\_classic\_components.mouth\_01 package
+====================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.mouth_01.guide
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.mouth_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.mouth_02.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.mouth_02.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.mouth\_02.guide module
+=========================================================
+
+.. automodule:: mgear.shifter_classic_components.mouth_02.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.mouth_02.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.mouth_02.rst
@@ -1,0 +1,18 @@
+mgear.shifter\_classic\_components.mouth\_02 package
+====================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.mouth_02.guide
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.mouth_02
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.neck_ik_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.neck_ik_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.neck\_ik\_01.guide module
+============================================================
+
+.. automodule:: mgear.shifter_classic_components.neck_ik_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.neck_ik_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.neck_ik_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.neck\_ik\_01 package
+=======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.neck_ik_01.guide
+   mgear.shifter_classic_components.neck_ik_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.neck_ik_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.neck_ik_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.neck_ik_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.neck\_ik\_01.settingsUI module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.neck_ik_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.rst
@@ -1,0 +1,65 @@
+mgear.shifter\_classic\_components package
+==========================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.arm_2jnt_01
+   mgear.shifter_classic_components.arm_2jnt_02
+   mgear.shifter_classic_components.arm_2jnt_03
+   mgear.shifter_classic_components.arm_2jnt_04
+   mgear.shifter_classic_components.arm_2jnt_freeTangents_01
+   mgear.shifter_classic_components.arm_ms_2jnt_01
+   mgear.shifter_classic_components.cable_01
+   mgear.shifter_classic_components.chain_01
+   mgear.shifter_classic_components.chain_FK_spline_01
+   mgear.shifter_classic_components.chain_FK_spline_02
+   mgear.shifter_classic_components.chain_FK_spline_variable_IK_01
+   mgear.shifter_classic_components.chain_IK_spline_variable_FK_01
+   mgear.shifter_classic_components.chain_IK_spline_variable_FK_stack_01
+   mgear.shifter_classic_components.chain_loc_ori_01
+   mgear.shifter_classic_components.chain_net_01
+   mgear.shifter_classic_components.chain_spring_01
+   mgear.shifter_classic_components.chain_spring_lite_stack_master_01
+   mgear.shifter_classic_components.chain_stack_01
+   mgear.shifter_classic_components.chain_whip_01
+   mgear.shifter_classic_components.control_01
+   mgear.shifter_classic_components.eye_01
+   mgear.shifter_classic_components.foot_bk_01
+   mgear.shifter_classic_components.hydraulic_01
+   mgear.shifter_classic_components.leg_2jnt_01
+   mgear.shifter_classic_components.leg_2jnt_02
+   mgear.shifter_classic_components.leg_2jnt_freeTangents_01
+   mgear.shifter_classic_components.leg_3jnt_01
+   mgear.shifter_classic_components.leg_ms_2jnt_01
+   mgear.shifter_classic_components.lite_chain_01
+   mgear.shifter_classic_components.lite_chain_stack_01
+   mgear.shifter_classic_components.lite_chain_stack_02
+   mgear.shifter_classic_components.meta_01
+   mgear.shifter_classic_components.mouth_01
+   mgear.shifter_classic_components.mouth_02
+   mgear.shifter_classic_components.neck_ik_01
+   mgear.shifter_classic_components.sdk_control_01
+   mgear.shifter_classic_components.shoulder_01
+   mgear.shifter_classic_components.shoulder_02
+   mgear.shifter_classic_components.shoulder_ms_01
+   mgear.shifter_classic_components.spine_FK_01
+   mgear.shifter_classic_components.spine_S_shape_01
+   mgear.shifter_classic_components.spine_ik_01
+   mgear.shifter_classic_components.spine_ik_02
+   mgear.shifter_classic_components.squash4Sides_01
+   mgear.shifter_classic_components.squash_01
+   mgear.shifter_classic_components.tangent_spline_01
+   mgear.shifter_classic_components.ui_container_01
+   mgear.shifter_classic_components.ui_slider_01
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.sdk_control_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.sdk_control_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.sdk\_control\_01.guide module
+================================================================
+
+.. automodule:: mgear.shifter_classic_components.sdk_control_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.sdk_control_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.sdk_control_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.sdk\_control\_01 package
+===========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.sdk_control_01.guide
+   mgear.shifter_classic_components.sdk_control_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.sdk_control_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.sdk_control_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.sdk_control_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.sdk\_control\_01.settingsUI module
+=====================================================================
+
+.. automodule:: mgear.shifter_classic_components.sdk_control_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.shoulder\_01.guide module
+============================================================
+
+.. automodule:: mgear.shifter_classic_components.shoulder_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.shoulder\_01 package
+=======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.shoulder_01.guide
+   mgear.shifter_classic_components.shoulder_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.shoulder_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.shoulder\_01.settingsUI module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.shoulder_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_02.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_02.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.shoulder\_02.guide module
+============================================================
+
+.. automodule:: mgear.shifter_classic_components.shoulder_02.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_02.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_02.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.shoulder\_02 package
+=======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.shoulder_02.guide
+   mgear.shifter_classic_components.shoulder_02.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.shoulder_02
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_02.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_02.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.shoulder\_02.settingsUI module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.shoulder_02.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_ms_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_ms_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.shoulder\_ms\_01.guide module
+================================================================
+
+.. automodule:: mgear.shifter_classic_components.shoulder_ms_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.shoulder_ms_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.shoulder_ms_01.rst
@@ -1,0 +1,18 @@
+mgear.shifter\_classic\_components.shoulder\_ms\_01 package
+===========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.shoulder_ms_01.guide
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.shoulder_ms_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_FK_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_FK_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_FK\_01.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_FK_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_FK_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_FK_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.spine\_FK\_01 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.spine_FK_01.guide
+   mgear.shifter_classic_components.spine_FK_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.spine_FK_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_FK_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_FK_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_FK\_01.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_FK_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_S_shape_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_S_shape_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_S\_shape\_01.guide module
+===================================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_S_shape_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_S_shape_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_S_shape_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.spine\_S\_shape\_01 package
+==============================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.spine_S_shape_01.guide
+   mgear.shifter_classic_components.spine_S_shape_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.spine_S_shape_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_S_shape_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_S_shape_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_S\_shape\_01.settingsUI module
+========================================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_S_shape_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_ik_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_ik_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_ik\_01.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_ik_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_ik_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_ik_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.spine\_ik\_01 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.spine_ik_01.guide
+   mgear.shifter_classic_components.spine_ik_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.spine_ik_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_ik_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_ik_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_ik\_01.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_ik_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_ik_02.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_ik_02.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_ik\_02.guide module
+=============================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_ik_02.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_ik_02.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_ik_02.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.spine\_ik\_02 package
+========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.spine_ik_02.guide
+   mgear.shifter_classic_components.spine_ik_02.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.spine_ik_02
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.spine_ik_02.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.spine_ik_02.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.spine\_ik\_02.settingsUI module
+==================================================================
+
+.. automodule:: mgear.shifter_classic_components.spine_ik_02.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.squash4Sides_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.squash4Sides_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.squash4Sides\_01.guide module
+================================================================
+
+.. automodule:: mgear.shifter_classic_components.squash4Sides_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.squash4Sides_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.squash4Sides_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.squash4Sides\_01 package
+===========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.squash4Sides_01.guide
+   mgear.shifter_classic_components.squash4Sides_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.squash4Sides_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.squash4Sides_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.squash4Sides_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.squash4Sides\_01.settingsUI module
+=====================================================================
+
+.. automodule:: mgear.shifter_classic_components.squash4Sides_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.squash_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.squash_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.squash\_01.guide module
+==========================================================
+
+.. automodule:: mgear.shifter_classic_components.squash_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.squash_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.squash_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.squash\_01 package
+=====================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.squash_01.guide
+   mgear.shifter_classic_components.squash_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.squash_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.squash_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.squash_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.squash\_01.settingsUI module
+===============================================================
+
+.. automodule:: mgear.shifter_classic_components.squash_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.tangent_spline_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.tangent_spline_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.tangent\_spline\_01.guide module
+===================================================================
+
+.. automodule:: mgear.shifter_classic_components.tangent_spline_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.tangent_spline_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.tangent_spline_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.tangent\_spline\_01 package
+==============================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.tangent_spline_01.guide
+   mgear.shifter_classic_components.tangent_spline_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.tangent_spline_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.tangent_spline_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.tangent_spline_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.tangent\_spline\_01.settingsUI module
+========================================================================
+
+.. automodule:: mgear.shifter_classic_components.tangent_spline_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.ui_container_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.ui_container_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.ui\_container\_01.guide module
+=================================================================
+
+.. automodule:: mgear.shifter_classic_components.ui_container_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.ui_container_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.ui_container_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.ui\_container\_01 package
+============================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.ui_container_01.guide
+   mgear.shifter_classic_components.ui_container_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.ui_container_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.ui_container_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.ui_container_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.ui\_container\_01.settingsUI module
+======================================================================
+
+.. automodule:: mgear.shifter_classic_components.ui_container_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.ui_slider_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.ui_slider_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.ui\_slider\_01.guide module
+==============================================================
+
+.. automodule:: mgear.shifter_classic_components.ui_slider_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.ui_slider_01.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.ui_slider_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_classic\_components.ui\_slider\_01 package
+=========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_classic_components.ui_slider_01.guide
+   mgear.shifter_classic_components.ui_slider_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_classic_components.ui_slider_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_classic_components.ui_slider_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_classic_components.ui_slider_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_classic\_components.ui\_slider\_01.settingsUI module
+===================================================================
+
+.. automodule:: mgear.shifter_classic_components.ui_slider_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_arm_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_arm_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_arm\_01.guide module
+==========================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_arm_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_arm_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_arm_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_arm\_01 package
+=====================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_arm_01.guide
+   mgear.shifter_epic_components.EPIC_arm_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_arm_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_arm_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_arm_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_arm\_01.settingsUI module
+===============================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_arm_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_chain_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_chain_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_chain\_01.guide module
+============================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_chain_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_chain_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_chain_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_chain\_01 package
+=======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_chain_01.guide
+   mgear.shifter_epic_components.EPIC_chain_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_chain_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_chain_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_chain_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_chain\_01.settingsUI module
+=================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_chain_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_control_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_control_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_control\_01.guide module
+==============================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_control_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_control_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_control_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_control\_01 package
+=========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_control_01.guide
+   mgear.shifter_epic_components.EPIC_control_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_control_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_control_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_control_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_control\_01.settingsUI module
+===================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_control_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_foot_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_foot_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_foot\_01.guide module
+===========================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_foot_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_foot_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_foot_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_foot\_01 package
+======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_foot_01.guide
+   mgear.shifter_epic_components.EPIC_foot_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_foot_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_foot_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_foot_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_foot\_01.settingsUI module
+================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_foot_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_hydraulic_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_hydraulic_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_hydraulic\_01.guide module
+================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_hydraulic_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_hydraulic_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_hydraulic_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_hydraulic\_01 package
+===========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_hydraulic_01.guide
+   mgear.shifter_epic_components.EPIC_hydraulic_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_hydraulic_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_hydraulic_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_hydraulic_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_hydraulic\_01.settingsUI module
+=====================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_hydraulic_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_leg_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_leg_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_leg\_01.guide module
+==========================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_leg_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_leg_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_leg_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_leg\_01 package
+=====================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_leg_01.guide
+   mgear.shifter_epic_components.EPIC_leg_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_leg_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_leg_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_leg_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_leg\_01.settingsUI module
+===============================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_leg_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_arm_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_arm_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_mannequin\_arm\_01.guide module
+=====================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_mannequin_arm_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_arm_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_arm_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_mannequin\_arm\_01 package
+================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_mannequin_arm_01.guide
+   mgear.shifter_epic_components.EPIC_mannequin_arm_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_mannequin_arm_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_arm_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_arm_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_mannequin\_arm\_01.settingsUI module
+==========================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_mannequin_arm_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_leg_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_leg_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_mannequin\_leg\_01.guide module
+=====================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_mannequin_leg_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_leg_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_leg_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_mannequin\_leg\_01 package
+================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_mannequin_leg_01.guide
+   mgear.shifter_epic_components.EPIC_mannequin_leg_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_mannequin_leg_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_leg_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_mannequin_leg_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_mannequin\_leg\_01.settingsUI module
+==========================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_mannequin_leg_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_neck_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_neck_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_neck\_01.guide module
+===========================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_neck_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_neck_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_neck_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_neck\_01 package
+======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_neck_01.guide
+   mgear.shifter_epic_components.EPIC_neck_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_neck_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_neck_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_neck_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_neck\_01.settingsUI module
+================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_neck_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_shoulder_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_shoulder_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_shoulder\_01.guide module
+===============================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_shoulder_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_shoulder_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_shoulder_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_shoulder\_01 package
+==========================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_shoulder_01.guide
+   mgear.shifter_epic_components.EPIC_shoulder_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_shoulder_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_shoulder_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_shoulder_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_shoulder\_01.settingsUI module
+====================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_shoulder_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_spine\_01.guide module
+============================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_spine_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_spine\_01 package
+=======================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_spine_01.guide
+   mgear.shifter_epic_components.EPIC_spine_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_spine_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_spine\_01.settingsUI module
+=================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_spine_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_cartoon_01.guide.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_cartoon_01.guide.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_spine\_cartoon\_01.guide module
+=====================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_spine_cartoon_01.guide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_cartoon_01.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_cartoon_01.rst
@@ -1,0 +1,19 @@
+mgear.shifter\_epic\_components.EPIC\_spine\_cartoon\_01 package
+================================================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_spine_cartoon_01.guide
+   mgear.shifter_epic_components.EPIC_spine_cartoon_01.settingsUI
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components.EPIC_spine_cartoon_01
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_cartoon_01.settingsUI.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.EPIC_spine_cartoon_01.settingsUI.rst
@@ -1,0 +1,7 @@
+mgear.shifter\_epic\_components.EPIC\_spine\_cartoon\_01.settingsUI module
+==========================================================================
+
+.. automodule:: mgear.shifter_epic_components.EPIC_spine_cartoon_01.settingsUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.shifter_epic_components.rst
+++ b/docs/source/mgear/mgear.shifter_epic_components.rst
@@ -1,0 +1,29 @@
+mgear.shifter\_epic\_components package
+=======================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.shifter_epic_components.EPIC_arm_01
+   mgear.shifter_epic_components.EPIC_chain_01
+   mgear.shifter_epic_components.EPIC_control_01
+   mgear.shifter_epic_components.EPIC_foot_01
+   mgear.shifter_epic_components.EPIC_hydraulic_01
+   mgear.shifter_epic_components.EPIC_leg_01
+   mgear.shifter_epic_components.EPIC_mannequin_arm_01
+   mgear.shifter_epic_components.EPIC_mannequin_leg_01
+   mgear.shifter_epic_components.EPIC_neck_01
+   mgear.shifter_epic_components.EPIC_shoulder_01
+   mgear.shifter_epic_components.EPIC_spine_01
+   mgear.shifter_epic_components.EPIC_spine_cartoon_01
+
+Module contents
+---------------
+
+.. automodule:: mgear.shifter_epic_components
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.simpleRig.menu.rst
+++ b/docs/source/mgear/mgear.simpleRig.menu.rst
@@ -1,0 +1,7 @@
+mgear.simpleRig.menu module
+===========================
+
+.. automodule:: mgear.simpleRig.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.simpleRig.rst
+++ b/docs/source/mgear/mgear.simpleRig.rst
@@ -1,0 +1,21 @@
+mgear.simpleRig package
+=======================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.simpleRig.menu
+   mgear.simpleRig.simpleRigTool
+   mgear.simpleRig.simpleRigUI
+   mgear.simpleRig.version
+
+Module contents
+---------------
+
+.. automodule:: mgear.simpleRig
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.simpleRig.simpleRigTool.rst
+++ b/docs/source/mgear/mgear.simpleRig.simpleRigTool.rst
@@ -1,0 +1,7 @@
+mgear.simpleRig.simpleRigTool module
+====================================
+
+.. automodule:: mgear.simpleRig.simpleRigTool
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.simpleRig.simpleRigUI.rst
+++ b/docs/source/mgear/mgear.simpleRig.simpleRigUI.rst
@@ -1,0 +1,7 @@
+mgear.simpleRig.simpleRigUI module
+==================================
+
+.. automodule:: mgear.simpleRig.simpleRigUI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.simpleRig.version.rst
+++ b/docs/source/mgear/mgear.simpleRig.version.rst
@@ -1,0 +1,7 @@
+mgear.simpleRig.version module
+==============================
+
+.. automodule:: mgear.simpleRig.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.menu.rst
+++ b/docs/source/mgear/mgear.synoptic.menu.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.menu module
+==========================
+
+.. automodule:: mgear.synoptic.menu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.rst
+++ b/docs/source/mgear/mgear.synoptic.rst
@@ -1,0 +1,29 @@
+mgear.synoptic package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.tabs
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.menu
+   mgear.synoptic.utils
+   mgear.synoptic.version
+   mgear.synoptic.widgets
+
+Module contents
+---------------
+
+.. automodule:: mgear.synoptic
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.baker.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.baker.rst
@@ -1,0 +1,18 @@
+mgear.synoptic.tabs.baker package
+=================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.tabs.baker.widget
+
+Module contents
+---------------
+
+.. automodule:: mgear.synoptic.tabs.baker
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.baker.widget.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.baker.widget.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.tabs.baker.widget module
+=======================================
+
+.. automodule:: mgear.synoptic.tabs.baker.widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.biped.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.biped.rst
@@ -1,0 +1,18 @@
+mgear.synoptic.tabs.biped package
+=================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.tabs.biped.widget
+
+Module contents
+---------------
+
+.. automodule:: mgear.synoptic.tabs.biped
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.biped.widget.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.biped.widget.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.tabs.biped.widget module
+=======================================
+
+.. automodule:: mgear.synoptic.tabs.biped.widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.control_list.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.control_list.rst
@@ -1,0 +1,19 @@
+mgear.synoptic.tabs.control\_list package
+=========================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.tabs.control_list.searchControlsWidget
+   mgear.synoptic.tabs.control_list.widget
+
+Module contents
+---------------
+
+.. automodule:: mgear.synoptic.tabs.control_list
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.control_list.searchControlsWidget.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.control_list.searchControlsWidget.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.tabs.control\_list.searchControlsWidget module
+=============================================================
+
+.. automodule:: mgear.synoptic.tabs.control_list.searchControlsWidget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.control_list.widget.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.control_list.widget.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.tabs.control\_list.widget module
+===============================================
+
+.. automodule:: mgear.synoptic.tabs.control_list.widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.quadruped.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.quadruped.rst
@@ -1,0 +1,18 @@
+mgear.synoptic.tabs.quadruped package
+=====================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.tabs.quadruped.widget
+
+Module contents
+---------------
+
+.. automodule:: mgear.synoptic.tabs.quadruped
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.quadruped.widget.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.quadruped.widget.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.tabs.quadruped.widget module
+===========================================
+
+.. automodule:: mgear.synoptic.tabs.quadruped.widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.rst
@@ -1,0 +1,22 @@
+mgear.synoptic.tabs package
+===========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.tabs.baker
+   mgear.synoptic.tabs.biped
+   mgear.synoptic.tabs.control_list
+   mgear.synoptic.tabs.quadruped
+   mgear.synoptic.tabs.visibility
+
+Module contents
+---------------
+
+.. automodule:: mgear.synoptic.tabs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.visibility.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.visibility.rst
@@ -1,0 +1,19 @@
+mgear.synoptic.tabs.visibility package
+======================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.synoptic.tabs.visibility.toggleGeoVisibilityWidget
+   mgear.synoptic.tabs.visibility.widget
+
+Module contents
+---------------
+
+.. automodule:: mgear.synoptic.tabs.visibility
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.visibility.toggleGeoVisibilityWidget.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.visibility.toggleGeoVisibilityWidget.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.tabs.visibility.toggleGeoVisibilityWidget module
+===============================================================
+
+.. automodule:: mgear.synoptic.tabs.visibility.toggleGeoVisibilityWidget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.tabs.visibility.widget.rst
+++ b/docs/source/mgear/mgear.synoptic.tabs.visibility.widget.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.tabs.visibility.widget module
+============================================
+
+.. automodule:: mgear.synoptic.tabs.visibility.widget
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.utils.rst
+++ b/docs/source/mgear/mgear.synoptic.utils.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.utils module
+===========================
+
+.. automodule:: mgear.synoptic.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.version.rst
+++ b/docs/source/mgear/mgear.synoptic.version.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.version module
+=============================
+
+.. automodule:: mgear.synoptic.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.synoptic.widgets.rst
+++ b/docs/source/mgear/mgear.synoptic.widgets.rst
@@ -1,0 +1,7 @@
+mgear.synoptic.widgets module
+=============================
+
+.. automodule:: mgear.synoptic.widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.vendor.Qt.rst
+++ b/docs/source/mgear/mgear.vendor.Qt.rst
@@ -1,0 +1,7 @@
+mgear.vendor.Qt module
+======================
+
+.. automodule:: mgear.vendor.Qt
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.vendor.qjsonmodel.rst
+++ b/docs/source/mgear/mgear.vendor.qjsonmodel.rst
@@ -1,0 +1,7 @@
+mgear.vendor.qjsonmodel module
+==============================
+
+.. automodule:: mgear.vendor.qjsonmodel
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.vendor.rst
+++ b/docs/source/mgear/mgear.vendor.rst
@@ -1,0 +1,19 @@
+mgear.vendor package
+====================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear.vendor.Qt
+   mgear.vendor.qjsonmodel
+
+Module contents
+---------------
+
+.. automodule:: mgear.vendor
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/mgear.version.rst
+++ b/docs/source/mgear/mgear.version.rst
@@ -1,0 +1,7 @@
+mgear.version module
+====================
+
+.. automodule:: mgear.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mgear/modules.rst
+++ b/docs/source/mgear/modules.rst
@@ -1,0 +1,7 @@
+mgear
+=====
+
+.. toctree::
+   :maxdepth: 4
+
+   mgear

--- a/docs/source/mgear/rigbits/blendshapes.rst
+++ b/docs/source/mgear/rigbits/blendshapes.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.blendShapes
-==============================
-
-.. automodule:: mgear.rigbits.blendShapes
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/channelWrangler.rst
+++ b/docs/source/mgear/rigbits/channelWrangler.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.channelWrangler
-==================================
-
-.. automodule:: mgear.rigbits.channelWrangler
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/cycleTweaks.rst
+++ b/docs/source/mgear/rigbits/cycleTweaks.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.cycleTweaks
-==============================
-
-.. automodule:: mgear.rigbits.cycleTweaks
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/eye_rigger.rst
+++ b/docs/source/mgear/rigbits/eye_rigger.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.eye_rigger
-=============================
-
-.. automodule:: mgear.rigbits.eye_rigger
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/ghost.rst
+++ b/docs/source/mgear/rigbits/ghost.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.ghost
-========================
-
-.. automodule:: mgear.rigbits.ghost
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/lips_rigger.rst
+++ b/docs/source/mgear/rigbits/lips_rigger.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.lips_rigger
-=============================
-
-.. automodule:: mgear.rigbits.lips_rigger
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/postSpring.rst
+++ b/docs/source/mgear/rigbits/postSpring.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.postSpring
-=============================
-
-.. automodule:: mgear.rigbits.postSpring
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/proxySlicer.rst
+++ b/docs/source/mgear/rigbits/proxySlicer.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.proxySlicer
-==============================
-
-.. automodule:: mgear.rigbits.proxySlicer
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/rbf_io.rst
+++ b/docs/source/mgear/rigbits/rbf_io.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.rbf_io
-==============================
-
-.. automodule:: mgear.rigbits.rbf_io
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/rbf_manager_ui.rst
+++ b/docs/source/mgear/rigbits/rbf_manager_ui.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.rbf_manager_ui
-==============================
-
-.. automodule:: mgear.rigbits.rbf_manager_ui
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/rbf_node.rst
+++ b/docs/source/mgear/rigbits/rbf_node.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.rbf_node
-==============================
-
-.. automodule:: mgear.rigbits.rbf_node
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/rigbits.rst
+++ b/docs/source/mgear/rigbits/rigbits.rst
@@ -1,6 +1,0 @@
-mgear.rigbits
-===================
-
-.. automodule:: mgear.rigbits
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/rivet.rst
+++ b/docs/source/mgear/rigbits/rivet.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.rivet
-========================
-
-.. automodule:: mgear.rigbits.rivet
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/rope.rst
+++ b/docs/source/mgear/rigbits/rope.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.rope
-=======================
-
-.. automodule:: mgear.rigbits.rope
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/sdk_io.rst
+++ b/docs/source/mgear/rigbits/sdk_io.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.sdk_io
-=================================
-
-.. automodule:: mgear.rigbits.sdk_io
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/tweaks.rst
+++ b/docs/source/mgear/rigbits/tweaks.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.tweaks
-=========================
-
-.. automodule:: mgear.rigbits.tweaks
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/utils.rst
+++ b/docs/source/mgear/rigbits/utils.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.utils
-========================
-
-.. automodule:: mgear.rigbits.utils
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/weightNode_io.rst
+++ b/docs/source/mgear/rigbits/weightNode_io.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.weightNode_io
-=================================
-
-.. automodule:: mgear.rigbits.weightNode_io
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/rigbits/widgets.rst
+++ b/docs/source/mgear/rigbits/widgets.rst
@@ -1,6 +1,0 @@
-mgear.rigbits.widgets
-=================================
-
-.. automodule:: mgear.rigbits.widgets
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/shifter/gui.rst
+++ b/docs/source/mgear/shifter/gui.rst
@@ -1,7 +1,0 @@
-mgear.shifter.gui
-======================
-
-
-.. automodule:: mgear.shifter.gui
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/shifter/guide.rst
+++ b/docs/source/mgear/shifter/guide.rst
@@ -1,7 +1,0 @@
-mgear.shifter.guide
-========================
-
-
-.. automodule:: mgear.shifter.guide
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/shifter/shifter.rst
+++ b/docs/source/mgear/shifter/shifter.rst
@@ -1,6 +1,0 @@
-mgear.shifter
-==================
-
-.. automodule:: mgear.shifter
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/shifter_classic_components/component.rst
+++ b/docs/source/mgear/shifter_classic_components/component.rst
@@ -1,6 +1,0 @@
-mgear.shifter_classic_components
-================================
-
-.. automodule:: mgear.shifter_classic_components
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/shifter_classic_components/guide.rst
+++ b/docs/source/mgear/shifter_classic_components/guide.rst
@@ -1,7 +1,0 @@
-mgear.shifter_classic_components.guide
-======================================
-
-
-.. automodule:: mgear.shifter_classic_components.guide
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/simpleRig/simpleRig.rst
+++ b/docs/source/mgear/simpleRig/simpleRig.rst
@@ -1,6 +1,0 @@
-mgear.simpleRig
-===================
-
-.. automodule:: mgear.simpleRig
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/simpleRig/simpleRigTool.rst
+++ b/docs/source/mgear/simpleRig/simpleRigTool.rst
@@ -1,6 +1,0 @@
-mgear.simpleRig.simpleRigTool
-=============================
-
-.. automodule:: mgear.simpleRig.simpleRigTool
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/synoptic/synoptic.rst
+++ b/docs/source/mgear/synoptic/synoptic.rst
@@ -1,6 +1,0 @@
-mgear.synoptic
-===================
-
-.. automodule:: mgear.synoptic
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/synoptic/utils.rst
+++ b/docs/source/mgear/synoptic/utils.rst
@@ -1,6 +1,0 @@
-mgear.synoptic.utils
-=========================
-
-.. automodule:: mgear.synoptic.utils
-	:members:
-	:undoc-members:

--- a/docs/source/mgear/synoptic/widgets.rst
+++ b/docs/source/mgear/synoptic/widgets.rst
@@ -1,7 +1,0 @@
-mgear.synoptic.widgets
-===========================
-
-
-.. automodule:: mgear.synoptic.widgets
-	:members:
-	:undoc-members:

--- a/docs/source/modulesList.rst
+++ b/docs/source/modulesList.rst
@@ -1,41 +1,9 @@
-
 Modules flat List
 =================
 
 Just a complete list of all modules.
 
 .. toctree::
+  :maxdepth: 4
 
-  mgear/core/core
-  mgear/core/applyop
-  mgear/core/attribute
-  mgear/core/curve
-  mgear/core/dag
-  mgear/core/fcurve
-  mgear/core/icon
-  mgear/core/log
-  mgear/core/menu
-  mgear/core/meshNavigation
-  mgear/core/node
-  mgear/core/pickWalk
-  mgear/core/primitive
-  mgear/core/skin
-  mgear/core/string
-  mgear/core/transform
-  mgear/core/utils
-  mgear/core/vector
-  mgear/core/widgets
-
-  mgear/shifter/shifter
-  mgear/shifter/guide
-  mgear/shifter/menu
-  mgear/shifter/gui
-  mgear/shifter/component/component
-  mgear/shifter/component/guide
-
-  mgear/synoptic/synoptic
-  mgear/synoptic/utils
-  mgear/synoptic/widgets
-
-  mgear/simpleRig/menu
-  mgear/simpleRig/simpleRigTool
+  mgear/modules

--- a/docs/source/official-unofficial-workflow.rst
+++ b/docs/source/official-unofficial-workflow.rst
@@ -74,7 +74,7 @@ FIRST THINGS TO KNOW About mGear
 
 	12) You can set up hotkeys to do some of the frequent mGear actions. mGear → Utilities → Create mGear hotkeys. This adds a bunch of actions in the Hotkey Editor. Then it is up to you to map them. I map "Build From Selection" to F7. And "Settings" to F6. Hitting F6 opens the module settings of the rig component I have selected.
 
-	13) **Control Icons:** When the rig is built, you can tweak or replace your control icons, and click "Extr. Ctl". This stands for "Extract Control" and it saves the icons inside the guide. The next time you build the script, it will use your custom icons. To reset to the default, you can simply delete the icons from inside the |guide|controllers_org group. You can also import icons from another character or another file. They are based on name. If names don't match, they won't be used.
+	13) **Control Icons:** When the rig is built, you can tweak or replace your control icons, and click "Extr. Ctl". This stands for "Extract Control" and it saves the icons inside the guide. The next time you build the script, it will use your custom icons. To reset to the default, you can simply delete the icons from inside the guide|controllers_org group. You can also import icons from another character or another file. They are based on name. If names don't match, they won't be used.
 
 	14) Saving your Skinning
 
@@ -148,6 +148,7 @@ Shifter build scripts will be kept under a separate "build" directory, and track
 
 * [ ] FIRST: Design the pipeline. The rigs will be built from guides. Figure out how to save this as a template asset that can easily be reused and iterated on.
 * [ ] Maybe write this as a Google Doc or a Wiki doc.
+
 The best way to install mGear is by putting it in a directory that can be accessed by your artists, and then pointed to by using the Maya environment variable MAYA_MODULE_PATH = /your/directory/here/foo
 
 If you are creating custom modules, you should store them in a separate directory of your choosing, and then point to it in your Maya.env by using MGEAR_SHIFTER_COMPONENT_PATH = /your/directory/here/foo

--- a/docs/source/quickStart.rst
+++ b/docs/source/quickStart.rst
@@ -11,9 +11,11 @@ To install mGear on your computer:
 1) Download the latest mGear release from here_.
 2) Unzip it
 3) Copy the content of the mGear **release** folder to your maya/modules folder:
+
  a) Windows: \Users\<username>\Documents\Maya\modules
  b) Linux: ~/maya/modules
  c) Mac OS X: ~/maya/modules
+ 
 4) Start Maya
 
 You should now have an mGear menu in Maya.

--- a/docs/source/rigbitsModules.rst
+++ b/docs/source/rigbitsModules.rst
@@ -41,3 +41,27 @@ Modules
    mgear.rigbits.weightNode_io
    mgear.rigbits.widgets
 
+
+.. toctree::
+   :maxdepth: 2
+
+   mgear/mgear.rigbits
+   mgear/mgear.rigbits.blendShapes
+   mgear/mgear.rigbits.channelWrangler
+   mgear/mgear.rigbits.cycleTweaks
+   mgear/mgear.rigbits.eye_rigger
+   mgear/mgear.rigbits.ghost
+   mgear/mgear.rigbits.lips_rigger
+   mgear/mgear.rigbits.menu
+   mgear/mgear.rigbits.postSpring
+   mgear/mgear.rigbits.proxySlicer
+   mgear/mgear.rigbits.rbf_io
+   mgear/mgear.rigbits.rbf_manager_ui
+   mgear/mgear.rigbits.rbf_node
+   mgear/mgear.rigbits.rivet
+   mgear/mgear/mgear.rigbits.rope
+   mgear/mgear.rigbits.sdk_io
+   mgear/mgear.rigbits.tweaks
+   mgear/mgear.rigbits.utils
+   mgear/mgear.rigbits.weightNode_io
+   mgear/mgear.rigbits.widgets

--- a/docs/source/shifterComponentReference.rst
+++ b/docs/source/shifterComponentReference.rst
@@ -1,4 +1,5 @@
 .. _shifter-component-reference:
+
 Shifter Component Reference
 ###########################
 

--- a/docs/source/shifterModules.rst
+++ b/docs/source/shifterModules.rst
@@ -16,7 +16,6 @@ Shifter can be use in a wide variety of projects. Animated feature films, video 
 Shifter have been build on top of mGear framework and can co-exist with other rigging systems inside mGear framework. In other words, if Shifter's paradigm doesn't fit your rigging needs, you can create another rigging system using the same mGear base modules.
 
 
-
 Modules
 --------
 
@@ -24,9 +23,11 @@ Modules
    :toctree: generated
 
    mgear.shifter
-   mgear.shifter.guide
-   mgear.shifter.gui
-   mgear.shifter.component
-   mgear.shifter.component.guide
 
+.. toctree::
+   :maxdepth: 2
 
+   mgear/mgear.shifter
+   mgear/mgear.shifter.guide
+   mgear/mgear.shifter.component
+   mgear/mgear.shifter.component.guide

--- a/docs/source/simpleRigModules.rst
+++ b/docs/source/simpleRigModules.rst
@@ -23,3 +23,9 @@ Modules
    mgear.simpleRig
    mgear.simpleRig.menu
    mgear.simpleRig.simpleRigTool
+
+.. toctree::
+   :maxdepth: 2
+   mgear/mgear.simpleRig
+   mgear/mgear.simpleRig.menu
+   mgear/mgear.simpleRig.simpleRigTool

--- a/docs/source/solvers.rst
+++ b/docs/source/solvers.rst
@@ -283,7 +283,7 @@ Spring dynamic solver based in goal position.
 
 
 mgear_squashStretch_attr
--------------------
+------------------------
 
 .. image:: images/solvers/mgear_squashStretch_node.png
     :align: center

--- a/docs/source/synopticModules.rst
+++ b/docs/source/synopticModules.rst
@@ -24,5 +24,10 @@ Modules
    :toctree: generated
 
    mgear.synoptic
-   mgear.synoptic.utils
-   mgear.synoptic.widgets
+
+.. toctree::
+   :maxdepth: 2
+
+   mgear/mgear.synoptic
+   mgear/mgear.synoptic.utils
+   mgear/mgear.synoptic.widgets

--- a/releaseLog.rst
+++ b/releaseLog.rst
@@ -353,7 +353,7 @@ Release Log
 	* Rigbits: RBF Manager: support for non-control objects  [mgear#228]
 
 2.5.24
------
+------
 **New Features**
 	* mGear: IO curves [mgear#76]
 	* Rigbits: RBF Manager [mgear#183]


### PR DESCRIPTION
https://github.com/mgear-dev/mgear4/issues/2

Following changes done:

- Re-generated mGear API docs using sphinx-apidoc. Ideally, in the future we should automatize this step by adding it as a pre-step within readthedocs build process.
- Fixed Sphinx conf.py file by fixing the path where mGear source is located and also setting up some autodoc_mock_imports, so some of the specific Maya modules (cmds, pymel, PySide) are ignored during the documentation building process.
- Added RigBits User Documentation.

I have generated readthedocs documentation with the docs within this branch. You can take a look at it here: https://mgear4.readthedocs.io/en/dev-2-sphinx-auto-doc-setup/