### PR TITLE
RBFManager: check if drivenControlName is valid before testing scene

### DIFF
--- a/release/scripts/mgear/rigbits/weightNode_io.py
+++ b/release/scripts/mgear/rigbits/weightNode_io.py
@@ -756,7 +756,7 @@ def createRBFFromInfo(weightNodeInfo_dict):
         driverControlPoseInfo = weightInfo.pop(rbf_node.DRIVER_POSES_INFO_ATTR,
                                                {})
 
-        if not mc.objExists(drivenControlName):
+        if drivenControlName is not None and not mc.objExists(drivenControlName):
             skipped_nodes.append(drivenControlName)
             continue
 


### PR DESCRIPTION
In answer to the issue reported here: https://github.com/mgear-dev/mgear4/issues/149