### PR TITLE
Adding support for namespaces and clashing names in skin io

### DIFF
--- a/release/scripts/mgear/core/skin.py
+++ b/release/scripts/mgear/core/skin.py
@@ -466,7 +466,6 @@ def getObjsFromSkinFile(filePath=None, *args):
 
 
 def importSkin(filePath=None, *args):
-    filePath = clash_and_namespace_fixer(filepath=filePath, toFile=True)
     if not filePath:
         f1 = 'mGear Skin (*{0} *{1})'.format(FILE_EXT, FILE_JSON_EXT)
         f2 = ";;gSkin Binary (*{0});;jSkin ASCII  (*{1})".format(

--- a/release/scripts/mgear/core/skin.py
+++ b/release/scripts/mgear/core/skin.py
@@ -207,10 +207,15 @@ def clash_and_namespace_fixer(filepath, toFile=True):
     # This is a gross approach, but it does work as Windows
     # supports ! (or CLASH_REPLACER if changed) but not |
     # Same with : Namespaces and NAMESPACE_REPLACER
+    filedir = os.path.dirname(filepath)
+    if filedir:
+        filedir = filedir + "/"
+    filename = os.path.basename(filepath)
+    raw_name, extension = os.path.splitext(filename)
     if toFile:
-        filepath = filepath.replace(":", NAMESPACE_REPLACER).replace("|", CLASH_REPLACER)
+        filepath = filedir + raw_name.replace(":", NAMESPACE_REPLACER).replace("|", CLASH_REPLACER) + extension
     else:
-        filepath = filepath.replace(NAMESPACE_REPLACER, ":").replace(CLASH_REPLACER, "|")
+        filepath = filedir + raw_name.replace(NAMESPACE_REPLACER, ":").replace(CLASH_REPLACER, "|") + extension
 
     return filepath
 
@@ -330,7 +335,7 @@ def exportSkinPack(packPath=None, objs=None, use_json=False, *args):
     packDic["rootPath"], packName = os.path.split(packPath)
 
     for obj in objs:
-        fileName = clash_and_namespace_fixer(filePath=obj.stripNamespace(), toFile=True) + file_ext
+        fileName = clash_and_namespace_fixer(filepath=obj.name(), toFile=True) + file_ext
         filePath = os.path.join(packDic["rootPath"], fileName)
         if exportSkin(filePath, [obj], use_json):
             packDic["packFiles"].append(fileName)
@@ -461,7 +466,7 @@ def getObjsFromSkinFile(filePath=None, *args):
 
 
 def importSkin(filePath=None, *args):
-    filePath = clash_and_namespace_fixer(filepath=filePath, toFile=False)
+    filePath = clash_and_namespace_fixer(filepath=filePath, toFile=True)
     if not filePath:
         f1 = 'mGear Skin (*{0} *{1})'.format(FILE_EXT, FILE_JSON_EXT)
         f2 = ";;gSkin Binary (*{0});;jSkin ASCII  (*{1})".format(
@@ -570,7 +575,7 @@ def importSkinPack(filePath=None, *args):
         packDic = json.load(fp)
         for pFile in packDic["packFiles"]:
             filePath = os.path.join(os.path.split(filePath)[0], pFile)
-            importSkin(filePath, True)
+            importSkin(clash_and_namespace_fixer(filepath=filePath, toFile=True), True)
 
 ######################################
 # Skin Copy

--- a/release/scripts/mgear/core/skin.py
+++ b/release/scripts/mgear/core/skin.py
@@ -23,6 +23,9 @@ FILE_EXT = ".gSkin"
 FILE_JSON_EXT = ".jSkin"
 PACK_EXT = ".gSkinPack"
 
+NAMESPACE_REPLACER = "~"
+CLASH_REPLACER = "!"
+
 ######################################
 # Skin getters
 ######################################
@@ -200,6 +203,17 @@ def collectData(skinCls, dataDic):
 # Skin export
 ######################################
 
+def clash_and_namespace_fixer(filepath, toFile=True):
+    # This is a gross approach, but it does work as Windows
+    # supports ! (or CLASH_REPLACER if changed) but not |
+    # Same with : Namespaces and NAMESPACE_REPLACER
+    if toFile:
+        filepath = filepath.replace(":", NAMESPACE_REPLACER).replace("|", CLASH_REPLACER)
+    else:
+        filepath = filepath.replace(NAMESPACE_REPLACER, ":").replace(CLASH_REPLACER, "|")
+
+    return filepath
+
 def exportSkin(filePath=None, objs=None, *args):
     if not objs:
         if pm.selected():
@@ -222,8 +236,7 @@ def exportSkin(filePath=None, objs=None, *args):
         filePath = pm.fileDialog2(fileMode=0,
                                   fileFilter=fileFilters)
         if filePath:
-            filePath = filePath[0]
-
+            filePath = clash_and_namespace_fixer(filepath=filePath[0], toFile=True)
         else:
             return False
 
@@ -317,7 +330,7 @@ def exportSkinPack(packPath=None, objs=None, use_json=False, *args):
     packDic["rootPath"], packName = os.path.split(packPath)
 
     for obj in objs:
-        fileName = obj.stripNamespace() + file_ext
+        fileName = clash_and_namespace_fixer(filePath=obj.stripNamespace(), toFile=True) + file_ext
         filePath = os.path.join(packDic["rootPath"], fileName)
         if exportSkin(filePath, [obj], use_json):
             packDic["packFiles"].append(fileName)
@@ -448,7 +461,7 @@ def getObjsFromSkinFile(filePath=None, *args):
 
 
 def importSkin(filePath=None, *args):
-
+    filePath = clash_and_namespace_fixer(filepath=filePath, toFile=False)
     if not filePath:
         f1 = 'mGear Skin (*{0} *{1})'.format(FILE_EXT, FILE_JSON_EXT)
         f2 = ";;gSkin Binary (*{0});;jSkin ASCII  (*{1})".format(


### PR DESCRIPTION
( as a possible fix for https://github.com/mgear-dev/mgear4/issues/172)

Adds a function to handle namespaces ( : ) and clashing names using full names ( | ) by replacing those characters with ones that Windows supports by default.
This is a bit of a gross approach, and maybe using a directory structure to handle it would be better, but this is an approach we're using and fixes all our name clash issues