### PR TITLE
mgear menu disappearing issue

### DIFF
--- a/release/scripts/mgear/menu.py
+++ b/release/scripts/mgear/menu.py
@@ -1,3 +1,4 @@
+from maya import cmds
 import pymel.core as pm
 import mgear
 import os
@@ -15,7 +16,7 @@ def create(menuId=menuId):
         str: main manu name
     """
 
-    if pm.menu(menuId, exists=True):
+    if cmds.menu(menuId, exists=True):
         try:
             pm.deleteUI(menuId)
         except RuntimeError:


### PR DESCRIPTION
Hi Miquel!

I'm looking into a problem where the mgear menu doesn't show up on new Maya installations(In my case it's 2023) and found the results of `pm.menu("....", exists=True)` to be unreliable.

```
# first time, returns ui.Menu object named False
pm.menu("any_non_existent_menu_name", exists=True)
# Result: ui.Menu('scriptEditorPanel1Window|scriptEditorPanel1|False')

# second time, returns boolean
pm.menu("any_non_existent_menu_name", exists=True)
# Result: False
```
This issue is occurring with most people on my team who have newly installed Maya, and it looks like it might be an issue with pymel 1.3.1 (In rare cases, it even returned True or None)
I'm not exactly sure what's causing the problem, but I thought it would be safer to use cmds just to check for menu existence.
