### PR TITLE
Fix create_spaces function that loads SpaceManager from SMD files

### DIFF
--- a/release/scripts/mgear/rigbits/space_manager/spaceManagerUtils.py
+++ b/release/scripts/mgear/rigbits/space_manager/spaceManagerUtils.py
@@ -12,11 +12,8 @@ import json as json
 
 def import_data(path):
     with open(path, "r") as read_file:
-        # Convert JSON file to Python Types
         obj = json.load(read_file)
-    data = json.dumps(obj, indent=4)
-    return data
-
+    return obj
 
 def create_constraints(dataSet):
     for constDict in dataSet:


### PR DESCRIPTION
Fixes import_data to return py object, not strings by removing redundant json.dumps. So patch_data function doesnt crash anymore.