### PR TITLE
Issue220 mirror shape custom names

### DIFF
--- a/release/scripts/mgear/rigbits/mirror_controls.py
+++ b/release/scripts/mgear/rigbits/mirror_controls.py
@@ -84,7 +84,6 @@ def get_opposite_control(node):
 
 
 def mirror_left_to_right():
-    # convention = get_guide_side_conventions()
     pairs = []
     for source in get_controls_with_label("L"):
         target = get_opposite_control(source)
@@ -95,7 +94,6 @@ def mirror_left_to_right():
 
 
 def mirror_right_to_left():
-    # convention = get_guide_side_conventions()
     pairs = []
     for source in get_controls_with_label("R"):
         target = get_opposite_control(source)

--- a/release/scripts/mgear/rigbits/mirror_controls.py
+++ b/release/scripts/mgear/rigbits/mirror_controls.py
@@ -64,7 +64,7 @@ def get_controls_with_label(side_label):
                 continue
             nodes.append(node)
 
-    nodes = [x for x in nodes if x.hasAttr('side_label') and x.side_label.get() == side_label]
+    nodes = [x for x in nodes if x.hasAttr("side_label") and x.side_label.get() == side_label]
 
     return nodes
 
@@ -77,7 +77,7 @@ def get_opposite_control(node):
     if pc.objExists(target_parent_name):
         target_parent = pc.PyNode(target_parent_name)
 
-    target_name = target_parent.listRelatives(children=1, type='transform')[0]
+    target_name = target_parent.listRelatives(children=1, type="transform")[0]
     target = pc.PyNode(target_name)
 
     return target

--- a/release/scripts/mgear/rigbits/mirror_controls.py
+++ b/release/scripts/mgear/rigbits/mirror_controls.py
@@ -77,7 +77,7 @@ def get_opposite_control(node):
     if pc.objExists(target_parent_name):
         target_parent = pc.PyNode(target_parent_name)
 
-    target_name = target_parent.listRelatives(c=1, type='transform')[0]
+    target_name = target_parent.listRelatives(children=1, type='transform')[0]
     target = pc.PyNode(target_name)
 
     return target


### PR DESCRIPTION
http://forum.mgear-framework.com/t/bug-naming-rules-mirror-shape/3389

Managed to work around the problem by using the parent of the ctl to find the appropiate mirror ctl. This way, we don't have to worry about weird ctl_name_rule configurations. 