### PR TITLE
Update weightNode_io.py

### DIFF
--- a/release/scripts/mgear/rigbits/weightNode_io.py
+++ b/release/scripts/mgear/rigbits/weightNode_io.py
@@ -136,9 +136,10 @@ def loadWeightPlugin(dependentFunc):
                     wd_version
                 )
             )
-        # just in case there is not SHAPES installed will try to load the
-        # weightDriver included with mGear
-        pm.loadPlugin("weightDriver", qt=True)
+        else:
+            # just in case there is not SHAPES installed will try to load the
+            # weightDriver included with mGear
+            pm.loadPlugin("weightDriver", qt=True)
 
     except RuntimeError:
         pm.displayWarning("RBF Manager couldn't found any valid RBF solver.")

--- a/release/scripts/mgear/rigbits/weightNode_io.py
+++ b/release/scripts/mgear/rigbits/weightNode_io.py
@@ -130,8 +130,7 @@ def loadWeightPlugin(dependentFunc):
         plugin_list = plugin_utils.get_all_available_plugins("weightDriver")
         plugin_utils.load_plugin_with_path(plugin_list, "weightDriver/plug-ins")
         wd_version = plugin_utils.get_plugin_version("weightDriver")
-        wd_version = plugin_utils.get_plugin_version("weightDriver")
-        if wd_version > "3.6.2":
+        if wd_version and wd_version > "3.6.2":
             pm.displayInfo(
                 "RBF Manager is using weightDriver version {} installed with SHAPES plugin".format(
                     wd_version


### PR DESCRIPTION
Fixed the uninstallation of the "weightDriver" plug-in in the python3 environment (maya2023, maya2024) because the "weightDriver/plug-ins" in line 131 is not in the list on line 130, so the variable value in line 132 is None, This error occurs when comparing row 134. `# Error: TypeError: '>' not supported between instances of 'NoneType' and 'str' #`