### PR TITLE
Title name was hidden due to the default width size is small.

### DIFF
--- a/release/scripts/mgear/rigbits/proxyGeo.py
+++ b/release/scripts/mgear/rigbits/proxyGeo.py
@@ -940,8 +940,8 @@ class proxyGeoUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         super(proxyGeoUI, self).__init__(parent)
 
         self.setWindowTitle("Proxy Geo Creator")
-        min_w = 155
-        default_w = 200
+        min_w = 230
+        default_w = 270
         default_h = 230
         self.setMinimumWidth(min_w)
         self.resize(default_w, default_h)


### PR DESCRIPTION
The title name became visible because the default width size was increased.

![image](https://github.com/mgear-dev/mgear4/assets/11863299/e77d248d-f2fe-42ec-9a81-8c5baba763fd)
