### PR TITLE
Shifter FBX anim clips: update set range and play buttons

### DIFF
--- a/release/scripts/mgear/shifter/game_tools_fbx/anim_clip_widgets.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/anim_clip_widgets.py
@@ -5,7 +5,7 @@ import maya.cmds as cmds
 from mgear.vendor.Qt import QtWidgets, QtCore, QtGui
 
 from mgear.core import pyqt
-from mgear.shifter.game_tools_fbx import fbx_export_node, utils as fbx_utils
+from mgear.shifter.game_tools_fbx import fbx_export_node, utils
 
 
 class AnimClipsListWidget(QtWidgets.QWidget):
@@ -109,7 +109,7 @@ class AnimClipsListWidget(QtWidgets.QWidget):
             )
             return
 
-        export_node = self._fbx_exporter.get_or_create_export_node()
+        export_node = fbx_export_node.FbxExportNode.get()
         anim_clip_name = export_node.add_animation_clip(self._root_joint)
         if not anim_clip_name:
             cmds.warning("Was not possible to add new animation clip")
@@ -133,14 +133,13 @@ class AnimClipsListWidget(QtWidgets.QWidget):
 class AnimClipWidget(QtWidgets.QFrame):
     def __init__(self, clip_name=None, parent=None):
         super(AnimClipWidget, self).__init__(parent)
-
         self._fbx_exporter = parent
         self._clip_name = clip_name
         self._previous_name = clip_name
 
         self.window().setAttribute(QtCore.Qt.WA_AlwaysShowToolTips, True)
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.setFixedHeight(40)
+        self.setFixedHeight(45)
 
         self.create_layout()
         self.create_connections()
@@ -254,12 +253,10 @@ class AnimClipWidget(QtWidgets.QFrame):
         with pyqt.block_signals(self._anim_layer_combo):
             self._anim_layer_combo.clear()
             # TODO: Maybe we should filter display layers that are set with override mode?
-            anim_layers = fbx_utils.all_anim_layers_ordered(
-                include_base_animation=False
-            )
+            anim_layers = utils.all_anim_layers_ordered()
             self._anim_layer_combo.addItems(["None"] + anim_layers)
             self._anim_layer_combo.setCurrentText(
-                anim_clip_data.get("animLayer", "None")
+                anim_clip_data.get("anim_layer", "None")
             )
 
     def set_enabled(self, flag):
@@ -276,9 +273,7 @@ class AnimClipWidget(QtWidgets.QFrame):
         if not export_node:
             return
 
-        root_joint = (
-            self._fbx_exporter.get_root_joint() if self._fbx_exporter else None
-        )
+        root_joint = self._fbx_exporter.get_root_joint()
         if not root_joint:
             return
 
@@ -287,9 +282,7 @@ class AnimClipWidget(QtWidgets.QFrame):
         self.deleteLater()
 
     def _on_update_anim_clip(self):
-        root_joint = (
-            self._fbx_exporter.get_root_joint() if self._fbx_exporter else None
-        )
+        root_joint = self._fbx_exporter.get_root_joint()
         if not root_joint:
             return
 
@@ -304,7 +297,7 @@ class AnimClipWidget(QtWidgets.QFrame):
         anim_clip_data["start_frame"] = int(self._start_frame_box.text())
         anim_clip_data["end_frame"] = int(self._end_frame_box.text())
         anim_layer = self._anim_layer_combo.currentText()
-        anim_clip_data["animLayer"] = (
+        anim_clip_data["anim_layer"] = (
             anim_layer if anim_layer and anim_layer != "None" else ""
         )
 
@@ -318,9 +311,11 @@ class AnimClipWidget(QtWidgets.QFrame):
         if not export_node:
             return
 
-        result = export_node.delete_animation_clip(
-            self._root_joint, self._clip_name
-        )
+        root_joint = self._fbx_exporter.get_root_joint()
+        if not root_joint:
+            return
+
+        result = export_node.delete_animation_clip(root_joint, self._clip_name)
         if not result:
             return
 
@@ -328,26 +323,25 @@ class AnimClipWidget(QtWidgets.QFrame):
         self.deleteLater()
 
     def _on_set_range_button_clicked(self):
-        start_frame = self._start_frame_box.text()
-        end_frame = self._end_frame_box.text()
-        cmds.playbackOptions(
-            animationStartTime=start_frame,
-            minTime=start_frame,
-            animationEndTime=end_frame,
-            maxTime=end_frame,
-        )
-        cmds.currentTime(start_frame, edit=True)
+        min_frame = str(int(cmds.playbackOptions(query=True, min=True)))
+        max_frame = str(int(cmds.playbackOptions(query=True, max=True)))
+        self._start_frame_box.setText(min_frame)
+        self._end_frame_box.setText(max_frame)
 
     def _on_play_button_clicked(self):
+        start_time = str(int(cmds.playbackOptions(query=True, ast=True)))
+        end_time = str(int(cmds.playbackOptions(query=True, aet=True)))
         start_frame = self._start_frame_box.text()
         end_frame = self._end_frame_box.text()
-        cmds.playbackOptions(
-            animationStartTime=start_frame,
-            minTime=start_frame,
-            animationEndTime=end_frame,
-            maxTime=end_frame,
-        )
-        if cmds.play(query=True, state=True):
+
+        if not (start_frame == start_time and end_frame == end_time):
+            cmds.playbackOptions(
+                animationStartTime=start_frame,
+                minTime=start_frame,
+                animationEndTime=end_frame,
+                maxTime=end_frame,
+            )
+        elif cmds.play(query=True, state=True):
             cmds.play(state=False)
         else:
             cmds.play(forward=True)
@@ -370,18 +364,18 @@ class AnimClipWidget(QtWidgets.QFrame):
 
         delete_anim_clip_action.triggered.connect(self._on_delete_anim_clip)
         playblast_25_action.triggered.connect(
-            partial(fbx_utils.create_mgear_playblast, scale=25)
+            partial(utils.create_mgear_playblast, scale=25)
         )
         playblast_50_action.triggered.connect(
-            partial(fbx_utils.create_mgear_playblast, scale=50)
+            partial(utils.create_mgear_playblast, scale=50)
         )
         playblast_75_action.triggered.connect(
-            partial(fbx_utils.create_mgear_playblast, scale=75)
+            partial(utils.create_mgear_playblast, scale=75)
         )
         playblast_100_action.triggered.connect(
-            partial(fbx_utils.create_mgear_playblast, scale=100)
+            partial(utils.create_mgear_playblast, scale=100)
         )
         open_playblasts_folder_action.triggered.connect(
-            fbx_utils.open_mgear_playblast_folder
+            utils.open_mgear_playblast_folder
         )
         context_menu.exec_(self.mapToGlobal(pos))

--- a/release/scripts/mgear/shifter/game_tools_fbx/fbx_export_node.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/fbx_export_node.py
@@ -32,7 +32,6 @@ class FbxExportNode(object):
     }
     ANIM_CLIP_DATA = {
         "title": "Untitled",
-        "path": "",
         "enabled": True,
         "frame_rate": "30 fps",
         "start_frame": int(pm.playbackOptions(min=True, query=True)),
@@ -220,7 +219,7 @@ class FbxExportNode(object):
         sequences = self.get_animation_clips(root_joint_name)
         total_sequences = len(sequences)
         clip_data = FbxExportNode.ANIM_CLIP_DATA.copy()
-        clip_data["title"] = "Clip {}".format(total_sequences + 1)
+        clip_data["title"] = "Clip_{}".format(total_sequences + 1)
         clip_data.update(anim_clip_data if anim_clip_data is not None else {})
 
         data = self.parse_export_data()

--- a/release/scripts/mgear/shifter/game_tools_fbx/fbx_exporter.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/fbx_exporter.py
@@ -351,10 +351,6 @@ class FBXExporter(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
         # partitions outliner
         self.partitions_outliner = partitions_outliner.PartitionsOutliner()
-        # self.partitions_outliner.setSizePolicy(
-        #     QtWidgets.QSizePolicy.MinimumExpanding,
-        #     QtWidgets.QSizePolicy.MinimumExpanding,
-        # )
         partitions_layout.addWidget(self.partitions_outliner)
 
         # partition buttons
@@ -704,10 +700,9 @@ class FBXExporter(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         print("\t>>> Preset File Path: {}".format(preset_file_path))
 
         export_config = self._get_current_tool_data()
-        for anim_clip_data in export_node.get_animation_clips(joint_root):
-            anim_clip_export_data = export_config.copy()
-            anim_clip_export_data.update(anim_clip_data)
-            utils.export_animation_clip(joint_root, anim_clip_export_data)
+        anim_clip_data = export_node.get_animation_clips(joint_root)
+        export_config["anim_clips"] = anim_clip_data
+        utils.export_animation_clip(export_config)
 
         return True
 


### PR DESCRIPTION
- Fixes bug in anim clips where I removed function to get the export node but forgot to replace it in anim_clips_widget.py, preventing clips from being added - my mistake, apologies for the oversight!
- Updates the "set range" button to set widget tool's animation time according to Maya's frame range
- Updates the "play" button to set Maya's frame range to tool data if different, and play the sequence if already set

The anim clips export is still WIP and I'll make another PR for that, but I wanted to get this out earlier so the widget can still add clips.

Relates to #117 