### PR TITLE
ueGear - Camera and Object connectivity

### DIFF
--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -51,6 +51,7 @@ def import_selected_assets_from_unreal():
     asset_export_datas = uegear_bridge.execute(
         "export_selected_assets", parameters={"directory": temp_folder}
     ).get("ReturnValue", list())
+    
     if not asset_export_datas:
         logger.warning(
             "Was not possible to export selected assets from Unreal"
@@ -366,8 +367,15 @@ def export_selected_assets_to_unreal(
     return True
 
 
-def export_cameras(self, cameras=None):
+def export_cameras(cameras=None):
     # TODO: WIP
+    """
+    This method is still under heavy development, as the surrounding API does not
+    yet have all the needed functionality implemented.
+
+    If this does not get implemented, please remove it.
+    """
+    # FIXME: export_layout_json, does not support camera objects
 
     cameras = utils.force_list(cameras or utils.get_selected_cameras())
     if not cameras:
@@ -378,6 +386,12 @@ def export_cameras(self, cameras=None):
     cameras_file = io.export_layout_json(
         nodes=cameras, output_path=temp_folder
     )
+
+    print(f"Camera Export Debug: {cameras_file}")
+
+
+    return False # Early exit for debugging reasons 
+
     result = self.execute(
         "import_maya_data_from_file", parameters={"data_file": cameras_file}
     )
@@ -583,3 +597,83 @@ def import_layout_from_unreal(self, export_assets=True):
 # 			os.remove(fbx_temp_file_path)
 # 		except Exception:
 # 			pass
+
+
+# NOT IMPLEMENTED
+def import_sequencer_cameras_timeline_from_unreal():
+    """
+    Imports the current active sequencer data from Unreal into Maya.
+    Imports:
+        - All Camera Tracks from Sequencer
+    Updates:
+        - Mayas Timerange, to match that of the sequencer.
+        - Maya FPS, to match that of the dequencer.
+    """
+    print("Import Sequencer's Cameras and Timeline data - In Development")
+
+    # [ ] Get active Sequencer in Unreal, else return
+    # [ ] Get Cameras in Sequencer, else return
+    # [ ] Get Sequencer Data, else return
+
+    # Unreal Cameras exported to location
+    # export FBX file into a temporal folder
+    temp_folder = tempfile.gettempdir()
+
+
+def import_selected_cameras_from_unreal():
+    print(f"Importing Selected Sequencer Cameras from Unreal...")
+
+    uegear_bridge = bridge.UeGearBridge()
+
+    # export FBX file into a temporal folder
+    temp_folder = tempfile.gettempdir()
+
+    # Send Unreal Command
+    
+    asset_export_datas = uegear_bridge.execute(
+        "export_selected_sequencer_cameras", 
+        parameters={"directory": temp_folder}
+    ).get("ReturnValue", list())
+    if not asset_export_datas:
+        logger.warning(
+            "Was not possible to export selected camera from Unreal"
+        )
+        return False
+    
+    # Loop over Unreal result
+
+    for asset_export_data in asset_export_datas:
+        # import asset from FBX file
+        fbx_file = asset_export_data.get("fbx_file", None)
+        if not fbx_file or not os.path.isfile(fbx_file):
+            logger.warning(
+                "No FBX file found for asset data: {}".format(
+                    asset_export_data
+                )
+            )
+            continue
+        logger.info('Importing Asset from FBX file: "{}"'.format(fbx_file))
+        imported_nodes = utils.import_fbx(fbx_file)
+
+        # tag imported transform nodes from FBX
+        transform_nodes = cmds.ls(imported_nodes, type="transform")
+        for transform_node in transform_nodes:
+            asset_type = asset_export_data.get("asset_type", "")
+            asset_name = asset_export_data.get("name", "")
+            asset_path = asset_export_data.get("path", "")
+            if asset_type:
+                tag.apply_tag(
+                    transform_node, tag.TAG_ASSET_TYPE_ATTR_NAME, asset_type
+                )
+            else:
+                tag.auto_tag(transform_node)
+            if asset_name:
+                tag.apply_tag(
+                    transform_node, tag.TAG_ASSET_NAME_ATTR_NAME, asset_name
+                )
+            if asset_path:
+                tag.apply_tag(
+                    transform_node, tag.TAG_ASSET_PATH_ATTR_NAME, asset_path
+                )
+
+    return True

--- a/release/scripts/mgear/uegear/menu.py
+++ b/release/scripts/mgear/uegear/menu.py
@@ -24,6 +24,10 @@ def install():
             str_export_selected_assets_to_unreal,
         ),
         ("-----", None),
+        (
+            "Import Selected Camers from Sequencer",
+            str_import_selected_cameras_from_unreal,
+        )
     )
 
     mgear.menu.install(menuID, commands, image="UE5.svg")
@@ -48,3 +52,13 @@ str_export_selected_assets_to_unreal = """
 from mgear.uegear import commands
 commands.export_selected_assets_to_unreal()
 """
+
+str_import_selected_cameras_from_unreal = """
+from mgear.uegear import commands
+commands.import_selected_cameras_from_unreal()
+"""
+
+# str_import_sequencer_cameras_timeline_from_unreal = """
+# from mgear.uegear import commands
+# commands.import_sequencer_cameras_timeline_from_unreal()
+# """

--- a/release/scripts/mgear/uegear/menu.py
+++ b/release/scripts/mgear/uegear/menu.py
@@ -27,7 +27,11 @@ def install():
         (
             "Import Selected Camers from Sequencer",
             str_import_selected_cameras_from_unreal,
-        )
+        ),
+        (
+            "Update Sequencer Camers from Maya Selection",
+            str_update_sequencer_camera_from_maya,
+        ),
     )
 
     mgear.menu.install(menuID, commands, image="UE5.svg")
@@ -58,7 +62,7 @@ from mgear.uegear import commands
 commands.import_selected_cameras_from_unreal()
 """
 
-# str_import_sequencer_cameras_timeline_from_unreal = """
-# from mgear.uegear import commands
-# commands.import_sequencer_cameras_timeline_from_unreal()
-# """
+str_update_sequencer_camera_from_maya = """
+from mgear.uegear import commands
+commands.update_sequencer_camera_from_maya()
+"""


### PR DESCRIPTION
This is the base implementation for ueGear and mGear

- Object Export and Import  Maya <- -> Unreal
- Camera Export and Import Maya <- -> Unreal

This must only be merged when the following ueGear pull request has been [completed](https://github.com/mgear-dev/ueGear/pull/5) 

The ueGear has not been exposed in mGear, as I will wait for @miquelcampos to give the go ahead, or uncomment the two lines. https://github.com/mgear-dev/mgear4/blob/9ce0a0b5bb8b8e9ad21d4720e2b8f2db346be4a1/release/scripts/mgear/menu.py#L132

Exporting objects does not export objects in the level, it exports objects in the Unreal Explorer.