### PR TITLE
Fixed the mirroring bug that occurs when using a custom control naming pattern or when side names 'L' and 'R' are changed.

### DIFF
--- a/release/scripts/mgear/core/attribute.py
+++ b/release/scripts/mgear/core/attribute.py
@@ -1168,17 +1168,15 @@ def get_guide_data_from_rig(*args):
     Returns:
         dict: a guide data
     """
-    selection = pm.ls(selection=True)
-    if not selection:
-        selection = pm.ls("rig")
-        if not selection or not selection[0].hasAttr("is_rig"):
-            mgear.log(
-                "Not rig root selected or found.\nSelect the rig root",
-                mgear.sev_error,
-            )
-            return
-    if selection[0].hasAttr("is_rig"):
-        guide_dict = selection[0].guide_data.get()
+    rigNode = pm.ls("rig")
+    if not rigNode or not rigNode[0].hasAttr("is_rig"):
+        mgear.log(
+            "Not rig root selected or found.\nSelect the rig root",
+            mgear.sev_error,
+        )
+        return
+    if rigNode[0].hasAttr("is_rig"):
+        guide_dict = rigNode[0].guide_data.get()
         return json.loads(guide_dict)
 
 

--- a/release/scripts/mgear/core/attribute.py
+++ b/release/scripts/mgear/core/attribute.py
@@ -4,6 +4,7 @@
 # GLOBAL
 #############################################
 import collections
+import json
 import mgear
 import pymel.core as pm
 import maya.cmds as cmds
@@ -1160,6 +1161,25 @@ def smart_reset(*args):
 ##########################################################
 # GETTERS
 ##########################################################
+
+def get_guide_data_from_rig(*args):
+    """Get guide data from a selected or default rig root
+
+    Returns:
+        dict: a guide data
+    """
+    selection = pm.ls(selection=True)
+    if not selection:
+        selection = pm.ls("rig")
+        if not selection or not selection[0].hasAttr("is_rig"):
+            mgear.log(
+                "Not rig root selected or found.\nSelect the rig root",
+                mgear.sev_error,
+            )
+            return
+    if selection[0].hasAttr("is_rig"):
+        guide_dict = selection[0].guide_data.get()
+        return json.loads(guide_dict)
 
 
 def get_channelBox():


### PR DESCRIPTION
The fix involves swapping the side label in control names based on the rig’s naming convention. It adapts dynamically by using guide data’s naming patterns to identify and swap the current side label, e.g., from ‘L’ to ‘R’ and vice versa."

The function uses the guide data's naming patterns to identify the current side label,
(e.g., "L", "R", etc.) in the provided name, and swap it to the opposite side.

Reported: 
http://forum.mgear-framework.com/t/control-mirroring-broken/3687