### PR TITLE
Added a dagmenu to reset all controllers, and organized the menus with a submenu.

### DIFF
--- a/release/scripts/mgear/core/dagmenu.py
+++ b/release/scripts/mgear/core/dagmenu.py
@@ -715,12 +715,12 @@ def mgear_dagmenu_fill(parent_menu, current_control):
         image="holder.svg",
     )
 
-    # reset all below
-    cmds.menuItem(
-        parent=parent_menu,
-        label="Reset all below",
-        command=partial(reset_all_keyable_attributes, child_controls),
-    )
+    resetOption = cmds.menuItem(
+            parent=parent_menu,
+            subMenu=True,
+            tearOff=False,
+            label="Reset Option",
+        )
 
     # reset all
     selection_set = cmds.ls(
@@ -728,10 +728,20 @@ def mgear_dagmenu_fill(parent_menu, current_control):
     )
     all_rig_controls = cmds.sets(selection_set, query=True)
     cmds.menuItem(
-        parent=parent_menu,
+        parent=resetOption,
         label="Reset all",
         command=partial(reset_all_keyable_attributes, all_rig_controls),
     )
+
+    # reset all below
+    cmds.menuItem(
+        parent=resetOption,
+        label="Reset all below",
+        command=partial(reset_all_keyable_attributes, child_controls),
+    )
+
+    # divider
+    cmds.menuItem(parent=resetOption, divider=True)
 
     # add transform resets
     k_attrs = cmds.listAttr(current_control, keyable=True) or []
@@ -742,7 +752,7 @@ def mgear_dagmenu_fill(parent_menu, current_control):
             if attr == "translate":
                 icon = "move_M.png"
             cmds.menuItem(
-                parent=parent_menu,
+                parent=resetOption,
                 label="Reset {}".format(attr),
                 command=partial(
                     __reset_attributes_callback, _current_selection, attr

--- a/release/scripts/mgear/core/dagmenu.py
+++ b/release/scripts/mgear/core/dagmenu.py
@@ -722,6 +722,17 @@ def mgear_dagmenu_fill(parent_menu, current_control):
         command=partial(reset_all_keyable_attributes, child_controls),
     )
 
+    # reset all
+    selection_set = cmds.ls(
+        cmds.listConnections(current_control), type="objectSet"
+    )
+    all_rig_controls = cmds.sets(selection_set, query=True)
+    cmds.menuItem(
+        parent=parent_menu,
+        label="Reset all",
+        command=partial(reset_all_keyable_attributes, all_rig_controls),
+    )
+
     # add transform resets
     k_attrs = cmds.listAttr(current_control, keyable=True) or []
     for attr in ("translate", "rotate", "scale"):


### PR DESCRIPTION
- Added a function to reset all controllers.
- Organized menus related to resets because the menu list became quite long.

![image](https://github.com/mgear-dev/mgear4/assets/11863299/4e0bac9b-abfb-4fe5-84c5-f44ed480a8d6)