### PR TITLE
#289 WeightDriver Plugin detection

### DIFF
--- a/release/scripts/mgear/core/plugin_utils.py
+++ b/release/scripts/mgear/core/plugin_utils.py
@@ -59,7 +59,7 @@ def get_all_available_plugins():
     return plugins
 
 
-def get_available_plugin(plugin_name):
+def get_available_plugins(plugin_name):
     """
     Returns any available plugin paths that match the plugin_name specified.
     """
@@ -135,8 +135,11 @@ def load_plugin(plugin_name, plugin_path):
         return False
 
 
-# Function to load a plugin based on the path
 def load_plugin_with_path(plugin_tuples, dir_name):
+    """
+    Loads a plugin by name that contains the matching relative path.
+    """
+
     # Check if the desired plugin is already loaded
     for plugin_name, plugin_path in plugin_tuples:
         if dir_name.lower() in plugin_path.lower() and cmds.pluginInfo(

--- a/release/scripts/mgear/core/plugin_utils.py
+++ b/release/scripts/mgear/core/plugin_utils.py
@@ -49,7 +49,13 @@ def get_all_available_plugins():
                 # Check if the filename contains the name you're looking for
                 if (file.endswith(".mll") or file.endswith(".so") or file.endswith(".bundle")):
                     # Create a tuple with the plugin name and path, and add it to the list
-                    plugins.append((file, os.path.join(path, file)))
+
+                    # Check if filetype exists, and removes it
+                    if file.find('.') > -1:
+                        parts = file.split('.')
+                        name = ".".join(parts[:-1])
+
+                    plugins.append((name, os.path.join(path, file)))
 
     return plugins
 
@@ -62,15 +68,8 @@ def get_available_plugin(plugin_name):
     available_plugins = []
 
     for plugin in all_plugins:
-        name = plugin[0]
-
-        # Check if filetype exists, and removes it
-        if plugin[0].find('.') > -1:
-            parts = plugin[0].split('.')
-            name = ".".join(parts[:-1])
-
-        if name == plugin_name:
-            available_plugins.append((name, plugin[1]))
+        if plugin[0] == plugin_name:
+            available_plugins.append(plugin)
 
     return available_plugins
 

--- a/release/scripts/mgear/rigbits/weightNode_io.py
+++ b/release/scripts/mgear/rigbits/weightNode_io.py
@@ -120,6 +120,9 @@ RBF_TYPE = "weightDriver"
 def loadWeightPlugin(dependentFunc):
     """ensure that plugin is always loaded prior to importing from json
 
+    Note: No assumption has been made about plugin location, we loop over 
+        available plugin, and check for the highest version.
+
     Args:
         dependentFunc (func): any function that needs to have plugin loaded
 
@@ -128,18 +131,23 @@ def loadWeightPlugin(dependentFunc):
     """
     try:
         plugin_list = plugin_utils.get_available_plugins("weightDriver")
-        plugin_utils.load_plugin_with_path(plugin_list, "weightDriver/plug-ins")
-        wd_version = plugin_utils.get_plugin_version("weightDriver")
-        if wd_version and wd_version > "3.6.2":
-            pm.displayInfo(
-                "RBF Manager is using weightDriver version {} installed with SHAPES plugin".format(
-                    wd_version
+        
+        # only one weightDriver plugin
+        if len(plugin_list) == 1:
+            return dependentFunc
+        
+        # Loop over weight plugins, enable and test version
+        for plugin_data in plugin_list:
+            plugin_utils.load_plugin(*plugin_data)
+            wd_version = plugin_utils.get_plugin_version("weightDriver")
+
+            if wd_version and wd_version > "3.6.2":
+                pm.displayInfo(
+                    "RBF Manager is using weightDriver version {} installed with SHAPES plugin".format(
+                        wd_version
+                    )
                 )
-            )
-        else:
-            # just in case there is not SHAPES installed will try to load the
-            # weightDriver included with mGear
-            pm.loadPlugin("weightDriver", qt=True)
+                break
 
     except RuntimeError:
         pm.displayWarning("RBF Manager couldn't found any valid RBF solver.")

--- a/release/scripts/mgear/rigbits/weightNode_io.py
+++ b/release/scripts/mgear/rigbits/weightNode_io.py
@@ -127,7 +127,7 @@ def loadWeightPlugin(dependentFunc):
         func: pass through of function
     """
     try:
-        plugin_list = plugin_utils.get_all_available_plugins("weightDriver")
+        plugin_list = plugin_utils.get_available_plugins("weightDriver")
         plugin_utils.load_plugin_with_path(plugin_list, "weightDriver/plug-ins")
         wd_version = plugin_utils.get_plugin_version("weightDriver")
         if wd_version and wd_version > "3.6.2":


### PR DESCRIPTION
The code is now OS friendly. Should work with all types of plugins [.mll, .bundle, .so]
Added an OS detector, as environment variables use different separators [ : ; ]

To detect if the plugin is the latest greater then the fallback plugin, I perform a loop over the available weightDriver plugins.
enable it, check the version, and if it is larger then break out of the loop.

All testing on my OSX Maya 2024 version worked correctly.

@miquelcampos please check on a windows machine.