### PR TITLE
Added pluginVersion Class and version limits

### DIFF
--- a/release/scripts/mgear/core/plugin_utils.py
+++ b/release/scripts/mgear/core/plugin_utils.py
@@ -3,6 +3,45 @@ import maya.mel as mel
 import maya.cmds as cmds
 
 
+class pluginVersion:
+    def __init__(self, version_str=None):
+        if version_str is None:
+            self.major = 0
+            self.minor = 0
+            self.patch = 0
+        else:
+            parts = version_str.split(".")
+            if len(parts) != 3:
+                raise ValueError("Invalid version string format. Must be 'major.minor.patch'")
+            try:
+                self.major = int(parts[0])
+                self.minor = int(parts[1])
+                self.patch = int(parts[2])
+            except ValueError:
+                raise ValueError("Invalid version number format. Must be integers.")
+
+    def __str__(self):
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    def __eq__(self, other):
+        return (self.major, self.minor, self.patch) == (other.major, other.minor, other.patch)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __lt__(self, other):
+        return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
+
+    def __le__(self, other):
+        return (self.major, self.minor, self.patch) <= (other.major, other.minor, other.patch)
+
+    def __gt__(self, other):
+        return (self.major, self.minor, self.patch) > (other.major, other.minor, other.patch)
+
+    def __ge__(self, other):
+        return (self.major, self.minor, self.patch) >= (other.major, other.minor, other.patch)
+
+
 def get_os():
     """
     Detects the current OS
@@ -175,7 +214,10 @@ def load_plugin_with_path(plugin_tuples, dir_name):
 
 
 def get_plugin_version(plugin_name):
+    """
+    Gets the plugin version of the plugin with the specified name, and returns a version object.
+    """
     if cmds.pluginInfo(plugin_name, q=True, loaded=True):
-        return cmds.pluginInfo(plugin_name, q=True, version=True)
+        return pluginVersion(cmds.pluginInfo(plugin_name, q=True, version=True))
     else:
         return None

--- a/release/scripts/mgear/rigbits/weightNode_io.py
+++ b/release/scripts/mgear/rigbits/weightNode_io.py
@@ -111,10 +111,10 @@ ENVELOPE_ATTR = "scale"
 
 WD_SUFFIX = "_WD"
 RBF_TYPE = "weightDriver"
+
 # ==============================================================================
 # General utils
 # ==============================================================================
-
 
 # Check for plugin
 def loadWeightPlugin(dependentFunc):
@@ -129,6 +129,13 @@ def loadWeightPlugin(dependentFunc):
     Returns:
         func: pass through of function
     """
+    maya_version = int(mc.about(version=True))
+
+    # maya2024+ cannot have a version lower then
+    maya_2024_lower_limit = plugin_utils.pluginVersion("3.6.2")
+    # maya2023- cannot have a version higher then
+    maya_2023_upper_limit = plugin_utils.pluginVersion("3.6.1")
+
     try:
         plugin_list = plugin_utils.get_available_plugins("weightDriver")
         
@@ -140,13 +147,19 @@ def loadWeightPlugin(dependentFunc):
         for plugin_data in plugin_list:
             plugin_utils.load_plugin(*plugin_data)
             wd_version = plugin_utils.get_plugin_version("weightDriver")
+            usingShapes = False
 
-            if wd_version and wd_version > "3.6.2":
-                pm.displayInfo(
-                    "RBF Manager is using weightDriver version {} installed with SHAPES plugin".format(
-                        wd_version
-                    )
-                )
+            if maya_version >= 2024:
+                if wd_version >= maya_2024_lower_limit:
+                    usingShapes = True
+            else:
+                if wd_version <= maya_2023_upper_limit:
+                    usingShapes = True
+
+            if usingShapes:
+                msg = "RBF Manager is using weightDriver version {} installed \
+with SHAPES plugin"
+                pm.displayInfo(msg.format(wd_version))
                 break
 
     except RuntimeError:


### PR DESCRIPTION
Created a new pluginVersion class, that will take a 3 version string Major, Minor,Patch "1.0.1" and convert it into three integers. The object also has all the comparison abilities and string representation.

Added in a limit check for Maya version pre 2024 and post 2024.

This should solve all the issues. I hope I got the versions correct, let me know if they are not meant to be inclusive

Ticket: #289 