### PR TITLE
Makes presets store whole node config. 

### DIFF
--- a/release/scripts/mgear/animbits/spring_manager/ui.py
+++ b/release/scripts/mgear/animbits/spring_manager/ui.py
@@ -271,8 +271,6 @@ class ConfigCollector(MayaQWidgetDockableMixin, QtWidgets.QDialog, pyqt.Settings
         """
         name = clicked_item.text()
         file_path = f"{self.presets_library_directory}/{name}{setup.SPRING_PRESET_EXTENSION}"
-        print(f"preset name = {name} \n"
-              f"file_path = {file_path}")
         setup.apply_preset(file_path)
 
     def delete_preset(self):


### PR DESCRIPTION
Presets now use the get_config function to store each node's name and attrs in a json. 
Double clicking the preset now builds the springs.