### PR TITLE
Shifter: Track and Unreal interfacing - #309

### DIFF
--- a/release/scripts/mgear/shifter/game_tools_fbx/anim_clip_widgets.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/anim_clip_widgets.py
@@ -255,9 +255,16 @@ class AnimClipWidget(QtWidgets.QFrame):
             # TODO: Maybe we should filter display layers that are set with override mode?
             anim_layers = animLayers.all_anim_layers_ordered()
             self._anim_layer_combo.addItems(["None"] + anim_layers)
-            self._anim_layer_combo.setCurrentText(
-                anim_clip_data.get("anim_layer", "None")
-            )
+            serialised_anim_layer = anim_clip_data.get("anim_layer", "None")
+
+            if not serialised_anim_layer:
+                serialised_anim_layer = "None"
+
+            # If serialised animation layer does not exist, notify user.
+            if self._anim_layer_combo.findText(serialised_anim_layer) > -1:
+                self._anim_layer_combo.setCurrentText(serialised_anim_layer)
+            else:
+                cmds.warning("Animation Layer not found: {}".format(serialised_anim_layer))
 
     def set_enabled(self, flag):
         self._export_checkbox.setChecked(flag)

--- a/release/scripts/mgear/shifter/game_tools_fbx/fbx_export_node.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/fbx_export_node.py
@@ -29,6 +29,9 @@ class FbxExportNode(object):
         "partitions": {},
         "anim_clips": {},
         "export_tab": 0,
+        "ue_enabled": False,
+        "ue_file_path": "",
+        "ue_active_skeleton":"",
     }
     ANIM_CLIP_DATA = {
         "title": "Untitled",
@@ -199,6 +202,10 @@ class FbxExportNode(object):
             .get("anim_clips", {})
             .get(root_joint_name, [])
         )
+
+    def get_ue_active_skeleton(self):
+        export_data = self.parse_export_data()
+        return export_data.get("ue_active_skeleton", None)
 
     def find_animation_clip(self, root_joint_name, clip_name):
         anim_clips = self.get_animation_clips(root_joint_name)

--- a/release/scripts/mgear/shifter/game_tools_fbx/utils.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/utils.py
@@ -302,6 +302,9 @@ def export_animation_clip(config_data, clip_data):
 
     config_data: The configuration for the scene/session
     clip_data: Information about the clip to be exported.
+
+    :return: return the path of the newly exported fbx.
+    :rtype: str
     """
     # Clip Data
     start_frame = clip_data.get("start_frame", 
@@ -471,7 +474,7 @@ def export_animation_clip(config_data, clip_data):
         # enable viewport
         mel.eval("paneLayout -e -manage true $gMainPane")
 
-    return True
+    return path
 
 
 def create_mgear_playblast(

--- a/release/scripts/mgear/shifter/game_tools_fbx/utils.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/utils.py
@@ -193,7 +193,7 @@ def export_skeletal_mesh(export_data):
                         )
                     )
 
-    return True
+    return export_path
 
 
 def export_skeletal_mesh_partitions(jnt_roots, export_data):

--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -841,7 +841,7 @@ def get_skeletal_data(skeletal_mesh=False):
     return result
 
 
-def get_selected_content_browser_folder():
+def get_selected_content_browser_folder(relative=False):
     """
     Returns the selected folder object in Unreals Content Browser.
 
@@ -853,6 +853,22 @@ def get_selected_content_browser_folder():
     uegear_bridge = bridge.UeGearBridge()
 
     result = uegear_bridge.execute("selected_content_browser_directory",
+        parameters={"relative": relative}
+        ).get("ReturnValue", [])
+
+    return result
+
+
+def export_animation_to_unreal(animation_path, unreal_folder_path, animation_name, skeleton_path):
+    print("[mGear] Importing Animation paths into Unreal.")
+
+    uegear_bridge = bridge.UeGearBridge()
+
+    result = uegear_bridge.execute("import_animation",
+        parameters={"animation_path": animation_path,
+                    "dest_path": unreal_folder_path,
+                    "name": animation_name,
+                    "skeleton_path": skeleton_path}
         ).get("ReturnValue", [])
 
     return result

--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -836,7 +836,22 @@ def get_skeletal_data(skeletal_mesh=False):
     result = uegear_bridge.execute("get_skeletons_data",
             parameters={"skeletal_mesh":skeletal_mesh}
         ).get("ReturnValue", [])
-    
+
     return result
 
 
+def get_selected_content_browser_folder():
+    """
+    Returns the selected folder object in Unreals Content Browser.
+
+    :return: Path to the selected folders in the content browser.
+    :rtype: [str]
+    """
+    print("[mGear] Retrieving Selected Content Browser Folder.")
+
+    uegear_bridge = bridge.UeGearBridge()
+
+    result = uegear_bridge.execute("selected_content_browser_directory",
+        ).get("ReturnValue", [])
+
+    return result

--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -653,6 +653,7 @@ def import_sequencer_cameras_timeline_from_unreal():
     # Unreal Cameras exported to location
     # export FBX file into a temporal folder
     temp_folder = tempfile.gettempdir()
+    raise NotImplementedError
 
 
 def import_selected_cameras_from_unreal():

--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -872,3 +872,35 @@ def export_animation_to_unreal(animation_path, unreal_folder_path, animation_nam
         ).get("ReturnValue", [])
 
     return result
+
+
+def export_skeletal_mesh_to_unreal(fbx_path, unreal_package_path, name, skeleton_path=None):
+    """
+    Examples
+        fbx_path = "/Computer/Documents/scenes/mgear_fbx_export/Butcher.fbx"
+        dest_path = "/Game/Character/Boy_4"
+        name = "Boy_4"
+    """
+    uegear_bridge = bridge.UeGearBridge()
+
+    options = str( {
+        "destination_name": name,
+        "skeleton": skeleton_path,
+        "mesh_type_to_import": True, # this is a weird implementation
+        "skeletal_mesh_import_data": str({
+            "preserve_smoothing_groups":True,
+            "import_morph_targets":True,
+            "convert_scene":True
+            })
+        } )
+
+    result = uegear_bridge.execute(
+        "import_skeletal_mesh",
+        parameters={
+            "fbx_file":fbx_path,
+            "import_path":unreal_package_path,
+            "import_options":options
+            }
+    ).get("ReturnValue", [])
+
+    return result

--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -819,3 +819,24 @@ def update_sequencer_camera_from_maya():
             print(p_e)
         except IOError as io_e:
             print(io_e)
+
+
+def get_skeletal_data(skeletal_mesh=False):
+    """
+    Queries Unreal for all the Skeletons or Skeletal Meshes that exist in the project.
+
+    :param bool skeletal_mesh: If True return SkeletalMesh data, False return Skeleton data.
+    :return: The package_name and asset_name. Stored in an Array of Key,Value pairs.
+    :rtype: [{}]
+    """
+    print("[mGear] Retrieving Skeletal Data.")
+
+    uegear_bridge = bridge.UeGearBridge()
+
+    result = uegear_bridge.execute("get_skeletons_data",
+            parameters={"skeletal_mesh":skeletal_mesh}
+        ).get("ReturnValue", [])
+    
+    return result
+
+


### PR DESCRIPTION
Ticket: #309

The Shifter now supports importing Skeleton Meshes (SKMs) and Animations into Unreal, at the same time as an export occurs from Maya.

3 Options
- Exporting Character, importing directly into Unreal
- Exporting Character, uses existing skeleton in Unreal
- Exporting Animation, uses existing skeleton in Unreal

NOTE: 
When creating an SKM, you want the skeleton to be in a default position, preferably with no animation on it. This returns the best results.

ueGear: https://github.com/mgear-dev/ueGear/pull/12