### PR TITLE
Partition Refreshes on import, or UI opening

### DIFF
--- a/release/scripts/mgear/shifter/game_tools_fbx/fbx_exporter.py
+++ b/release/scripts/mgear/shifter/game_tools_fbx/fbx_exporter.py
@@ -457,6 +457,10 @@ class FBXExporter(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         # animation connection
         self.anim_export_btn.clicked.connect(self.export_animation_clips)
 
+        # partition skinning connection
+        self.skinning_checkbox.toggled.connect(self.partition_skinning_toggled)
+        self.blendshapes_checkbox.toggled.connect(self.partition_blendshape_toggled)
+
     def get_root_joint(self):
         root_joint = self.joint_root_lineedit.text().split(",")
         return root_joint[0] if root_joint else None
@@ -569,6 +573,18 @@ class FBXExporter(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.partitions_label.setEnabled(flag)
         self.skmesh_add_btn.setEnabled(flag)
         self.skmesh_rem_btn.setEnabled(flag)
+
+    def partition_skinning_toggled(self):
+        """Updates the Maya FBX Node, when checkbox it changed"""
+        skinning_active = self.skinning_checkbox.isChecked()
+        export_node = self._get_or_create_export_node()
+        export_node.save_root_data("skinning", skinning_active)
+
+    def partition_blendshape_toggled(self):
+        """Updates the Maya FBX Node, when checkbox it changed"""
+        skinning_active = self.blendshapes_checkbox.isChecked()
+        export_node = self._get_or_create_export_node()
+        export_node.save_root_data("blendshapes", skinning_active)
 
     def add_skeletal_mesh_partition(self):
         export_node = self._get_or_create_export_node()
@@ -797,6 +813,10 @@ class FBXExporter(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.export_tab.setCurrentIndex(data.get("export_tab", 0))
         self.partitions_outliner.reset_contents()
         self.anim_clips_listwidget.refresh()
+
+        # Force the population of the Master partitions.
+        item_names = self._get_listwidget_item_names(self.geo_root_list)
+        self.partitions_outliner.set_geo_roots(item_names)
 
     def _update_geo_roots_data(self):
         export_node = self._get_or_create_export_node()


### PR DESCRIPTION
Ticket: #315 

- Master Partition was not populating after a config import or a reload of the UI
- Skigging and Blendshape checkboxes update maya node on toggle, and not just on close