### PR TITLE
Fix SpringManager Crash on Missing Data Folder

### DIFF
--- a/release/scripts/mgear/animbits/spring_manager/ui.py
+++ b/release/scripts/mgear/animbits/spring_manager/ui.py
@@ -275,6 +275,14 @@ class SpringManager(MayaQWidgetDockableMixin, QtWidgets.QDialog, pyqt.SettingsMi
         return tuple(presets)
 
     def set_library(self, directory=None):
+        """
+        Clears the preset list and populates a new one with the items of the given directory
+        Args:
+            directory:
+
+        Returns:
+
+        """
         if not directory:
             directory = pm.fileDialog2(fileMode=3)[0]
 
@@ -282,8 +290,9 @@ class SpringManager(MayaQWidgetDockableMixin, QtWidgets.QDialog, pyqt.SettingsMi
             if not os.path.isdir(directory):
                 print("Directory does not exist. Creating...")
                 os.makedirs(directory, exist_ok=True)
+
         except:
-            pm.error("Could not create a directory.")
+            pm.error("Could not create directory")
             return
 
         if not os.path.isdir(directory):

--- a/release/scripts/mgear/animbits/spring_manager/ui.py
+++ b/release/scripts/mgear/animbits/spring_manager/ui.py
@@ -275,16 +275,17 @@ class SpringManager(MayaQWidgetDockableMixin, QtWidgets.QDialog, pyqt.SettingsMi
         return tuple(presets)
 
     def set_library(self, directory=None):
-        """
-        Clears the preset list and populates a new one with the items of the given directory
-        Args:
-            directory:
-
-        Returns:
-
-        """
         if not directory:
             directory = pm.fileDialog2(fileMode=3)[0]
+
+        try:
+            if not os.path.isdir(directory):
+                print("Directory does not exist. Creating...")
+                os.makedirs(directory, exist_ok=True)
+        except:
+            pm.error("Could not create a directory.")
+            return
+
         if not os.path.isdir(directory):
             pm.error("Invalid directory")
             return


### PR DESCRIPTION
Previously if the SpringManager was opened without a pre-existing data folder it would crash. Added an  `os.makedirs(directory, exist_ok=True)` within the `set_library` function.
