### PR TITLE
Got a proper orientation for wrist using getTransformLookingAt, not orientation from an exact guide. 

### DIFF
--- a/release/scripts/mgear/shifter_classic_components/arm_2jnt_04/__init__.py
+++ b/release/scripts/mgear/shifter_classic_components/arm_2jnt_04/__init__.py
@@ -102,12 +102,11 @@ class Component(component.Main):
                                             self.negate)
        # Define the wrist transform (wt)
         if self.settings["guideOrientWrist"]:
-            wt = self.guide.tra["wrist"]
             if self.settings["mirrorIK"] and self.negate:
                 scl = [1, 1, -1]
             else:
                 scl = [1, 1, 1]
-            wt = transform.setMatrixScale(wt, scl)
+            wt = transform.setMatrixScale(t, scl)
             t = wt
 
         self.fk2_npo = primitive.addTransform(self.fk1_ctl,


### PR DESCRIPTION
Fixed: Arm_2jnt_04: orientation issue(the forearm jnt and ctl ) https://github.com/mgear-dev/mgear4/issues/337

The bug occurs when the Align wrist to guide orientation option is enabled.

In this case, the wrist matrix was initially defined based on a guide wrist orientation, which resulted in the wrist orientation being flipped in relation to the elbow and the shoulder joint, leading to a twist in the forearm joint and controller.

[Wrong Axis]
![image](https://github.com/mgear-dev/mgear4/assets/11863299/10770d24-2419-46b8-8155-2936276153b8)

[Correct Axis]
![image](https://github.com/mgear-dev/mgear4/assets/11863299/6337930b-8527-46f4-8f62-408247ca7403)
