### PR TITLE
The dagmenu for a guide can be accessed by selecting a guide node.

### DIFF
--- a/release/scripts/mgear/core/dagmenu.py
+++ b/release/scripts/mgear/core/dagmenu.py
@@ -634,7 +634,12 @@ def mgear_dagmenu_callback(*args, **kwargs):  # @UnusedVariable
     # the override
     if type(args[1]) != bool:
         sel = cmds.ls(selection=True, long=True, type="transform")
-        if sel and cmds.objExists("{}.isCtl".format(sel[0])):
+
+        isCtl = cmds.objExists("{}.isCtl".format(sel[0]))
+        isGuide = cmds.objExists("{}.rig_name".format(sel[0]))
+        isGearGuide = cmds.objExists("{}.isGearGuide".format(sel[0]))
+
+        if sel and isCtl:
             # cleans menu
             _parent_menu = parent_menu.replace('"', "")
             cmds.menu(_parent_menu, edit=True, deleteAllItems=True)
@@ -642,7 +647,7 @@ def mgear_dagmenu_callback(*args, **kwargs):  # @UnusedVariable
             # fills menu
             mgear_dagmenu_fill(_parent_menu, sel[0])
 
-        elif sel and cmds.objExists("{}.isGearGuide".format(sel[0])):
+        elif sel and isGuide or sel and isGearGuide:
             # cleans menu
             _parent_menu = parent_menu.replace('"', "")
             cmds.menu(_parent_menu, edit=True, deleteAllItems=True)


### PR DESCRIPTION
![image](https://github.com/mgear-dev/mgear4/assets/11863299/18a0116e-0efb-42a3-9d90-e80b81720b9d)
