### PR TITLE
Updated the guide node

### DIFF
--- a/release/scripts/mgear/shifter/__init__.py
+++ b/release/scripts/mgear/shifter/__init__.py
@@ -379,7 +379,9 @@ class Rig(object):
         # --------------------------------------------------
         # Model
         self.model = primitive.addTransformFromPos(None, self.options["rig_name"])
-        attribute.lockAttribute(self.model)
+
+        lockAttrs = ["tx", "ty", "tz", "rx", "ry", "rz", "sx", "sy", "sz"]
+        attribute.lockAttribute(self.model, attributes=lockAttrs)
 
         # --------------------------------------------------
         # INFOS

--- a/release/scripts/mgear/shifter/component/__init__.py
+++ b/release/scripts/mgear/shifter/component/__init__.py
@@ -2097,6 +2097,10 @@ class Main(object):
 
                 self.jointList.append(self.addJoint(**jpo))
 
+        for jnt in self.jointList:
+            radiusValue = self.rig.guide.model.joint_radius.get()
+            jnt.radius.set(radiusValue)
+
     # =====================================================
     # FINALIZE
     # =====================================================

--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -479,6 +479,10 @@ class Rig(Main):
             root = root.getParent()
             mgear.log(root)
 
+        if self.model.hasAttr("guide_vis"):
+            if not self.model.guide_vis.get():
+                self.model.hide()
+
         # ---------------------------------------------------
         # First check and set the options
         mgear.log("Get options")
@@ -715,9 +719,13 @@ class Rig(Main):
     def initialHierarchy(self):
         """Create the initial rig guide hierarchy (model, options...)"""
         self.model = pm.group(n="guide", em=True, w=True)
+
         if versions.current() >= 20220000:
             attribute.addAttribute(
                 self.model, "guide_x_ray", "bool", False, keyable=True)
+
+        attribute.addAttribute(
+            self.model, "guide_vis", "bool", False, keyable=True)
 
         attribute.addAttribute(
             self.model,

--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -719,6 +719,15 @@ class Rig(Main):
             attribute.addAttribute(
                 self.model, "guide_x_ray", "bool", False, keyable=True)
 
+        attribute.addAttribute(
+            self.model,
+            "joint_radius",
+            "double",
+            value=0.1,
+            minValue=0,
+            keyable=True
+        )
+
         # Options
         self.options = self.addPropertyParamenters(self.model)
 


### PR DESCRIPTION
### Added the guide_vis parameter to the guide node, 
_This feature allows you to hide the guide node when a boolean variable is turned off after the rig has been built._

### Added the joint_radius parameter to the guide node.
_This allows you to specify a specific joint radius._

![image](https://github.com/mgear-dev/mgear4/assets/11863299/34ab3f9f-f4db-43d5-a54c-db9d0c722f5a)

### Unlocked the visibility on a rig node.  
_There is a case to hide the rig node at some point._

![vis](https://github.com/mgear-dev/mgear4/assets/11863299/ae98c1fe-35bb-4d88-bbd5-cddb38abdd3b)
