### PR TITLE
Organizing all the skin joints into sub deformer sets as control sets.

### DIFF
--- a/release/scripts/mgear/animbits/softTweakWindowUI.ui
+++ b/release/scripts/mgear/animbits/softTweakWindowUI.ui
@@ -116,7 +116,7 @@
               <widget class="QLineEdit" name="name_lineEdit"/>
              </item>
              <item row="1" column="0">
-              <widget class="QLabel" name="ctlGrp_label">
+              <widget class="QLabel" name="customGrp_label">
                <property name="text">
                 <string>Ctl grp</string>
                </property>
@@ -125,7 +125,7 @@
              <item row="1" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_2">
                <item>
-                <widget class="QLineEdit" name="ctlGrp_lineEdit"/>
+                <widget class="QLineEdit" name="customGrp_lineEdit"/>
                </item>
                <item>
                 <widget class="QPushButton" name="setCtrlGrp_pushButton">

--- a/release/scripts/mgear/core/dagmenu.py
+++ b/release/scripts/mgear/core/dagmenu.py
@@ -851,10 +851,13 @@ def mgear_dagmenu_fill(parent_menu, current_control):
     )
 
     # reset all
-    selection_set = cmds.ls(
-        cmds.listConnections(current_control), type="objectSet"
-    )
-    all_rig_controls = cmds.sets(selection_set, query=True)
+    controls_set = cmds.ls("*_controllers_grp", type="objectSet")
+    all_rig_controls = set()
+    if controls_set:
+        members = cmds.sets(controls_set[0], query=True)
+        for member in members:
+            all_rig_controls.update(cmds.sets(member, q=True) or [])
+
     cmds.menuItem(
         parent=resetOption,
         label="Reset all",

--- a/release/scripts/mgear/shifter/__init__.py
+++ b/release/scripts/mgear/shifter/__init__.py
@@ -554,6 +554,12 @@ class Rig(object):
         pm.connectAttr(masterSet.message, self.model.rigGroups[groupIdx])
         groupIdx += 1
 
+        # Create deformer set
+        deformSet = pm.sets(n=self.model.name() + "_deformers_grp", em=True)
+        pm.connectAttr(deformSet.message, self.model.rigGroups[groupIdx])
+        masterSet.add(deformSet)
+        groupIdx += 1
+
         # Creating all groups
         pm.select(cl=True)
         for name, objects in self.groups.items():
@@ -571,7 +577,6 @@ class Rig(object):
                 pg.add(sub)
 
         # create geo group
-
         geoSet = pm.sets(n=self.model.name() + "_geo_grp", em=True)
         pm.connectAttr(geoSet.message, self.model.rigGroups[groupIdx])
         masterSet.add(geoSet)

--- a/release/scripts/mgear/shifter/component/__init__.py
+++ b/release/scripts/mgear/shifter/component/__init__.py
@@ -587,7 +587,12 @@ class Main(object):
             pm.connectAttr(self.rig.jntVis_att, jnt.attr("visibility"))
             attribute.lockAttribute(jnt)
 
-        self.addToGroup(jnt, "deformers")
+        if self.settings["ctlGrp"]:
+            jntGrp = "deformers_{}_{}".format(self.settings["ctlGrp"], self.side)
+            self.addToGroup(jnt, jntGrp, "deformers")
+        else:
+            jntGrp = "deformers_{}".format(self.getName())
+            self.addToGroup(jnt, jntGrp, "deformers")
 
         if guide_relative:
             if not jnt.hasAttr("guide_relative"):
@@ -757,7 +762,12 @@ class Main(object):
             pm.connectAttr(self.rig.jntVis_att, jnt.attr("visibility"))
             attribute.lockAttribute(jnt)
 
-        self.addToGroup(jnt, "deformers")
+        if self.settings["ctlGrp"]:
+            jntGrp = "deformers_{}_{}".format(self.settings["ctlGrp"], self.side)
+            self.addToGroup(jnt, jntGrp, "deformers")
+        else:
+            jntGrp = "deformers_{}".format(self.getName())
+            self.addToGroup(jnt, jntGrp, "deformers")
 
         # This is a workaround due the evaluation problem with compound attr
         # TODO: This workaround, should be removed onces the evaluation issue
@@ -998,11 +1008,11 @@ class Main(object):
         attribute.add_mirror_config_channels(ctl, mirrorConf)
         if add_2_grp:
             if self.settings["ctlGrp"]:
-                ctlGrp = self.settings["ctlGrp"]
+                ctlGrp = "{}_{}".format(self.settings["ctlGrp"], self.side)
                 self.addToGroup(ctl, ctlGrp, "controllers")
             else:
-                ctlGrp = "controllers"
-                self.addToGroup(ctl, ctlGrp)
+                ctlGrp = self.getName()
+                self.addToGroup(ctl, ctlGrp, "controllers")
 
             # lock the control parent attributes if is not a control
             if parent not in self.groups[ctlGrp] and lp:

--- a/release/scripts/mgear/shifter/component/main_settings_ui.py
+++ b/release/scripts/mgear/shifter/component/main_settings_ui.py
@@ -298,7 +298,7 @@ class Ui_Form(object):
         self.componentIndex_label.setText(QtWidgets.QApplication.translate("Form", "Component Index:", None, -1))
         self.conector_label.setText(QtWidgets.QApplication.translate("Form", "Connector:", None, -1))
         self.connector_comboBox.setItemText(0, QtWidgets.QApplication.translate("Form", "standard", None, -1))
-        self.groupBox_2.setTitle(QtWidgets.QApplication.translate("Form", "Custom Controllers Group", None, -1))
+        self.groupBox_2.setTitle(QtWidgets.QApplication.translate("Form", "Custom Group", None, -1))
         self.subGroup_lineEdit.setToolTip(QtWidgets.QApplication.translate("Form", "<html><head/><body><p>Name for a custom controllers Group (Maya set) for the component controllers.</p><p align=\"center\"><span style=\" font-weight:600;\">i.e</span>: Setting the name &quot;arm&quot; will create a sub group (sub set in Mayas terminology) with the name &quot;rig_arm_grp&quot;. This group will be under the &quot;rig_controllers_grp&quot;</p><p>Leave this option empty for the default behaviour.</p></body></html>", None, -1))
         self.jointSettings_groupBox.setTitle(QtWidgets.QApplication.translate("Form", "Joint Settings", None, -1))
         self.useJointIndex_checkBox.setText(QtWidgets.QApplication.translate("Form", "Parent Joint Index", None, -1))


### PR DESCRIPTION
https://github.com/mgear-dev/mgear4/issues/369
Organized the module joints and controllers into subsets, categorizing them by component name and their respective sides by default.

![image](https://github.com/mgear-dev/mgear4/assets/11863299/c500141a-5b0e-4335-887f-bcb9b9478c7e)
