### PR TITLE
Added the kwargs on the function import_guide_template

### DIFF
--- a/release/scripts/mgear/shifter/io.py
+++ b/release/scripts/mgear/shifter/io.py
@@ -170,13 +170,13 @@ def import_partial_guide(
                         model=rig.guide.model)
 
 
-def import_guide_template(filePath=None, conf=None, *args):
+def import_guide_template(filePath=None, conf=None, **kwargs):
     """Import a guide template
 
     Args:
         filePath (str, optional): Path to the template file to import
     """
-    import_partial_guide(filePath, conf=conf)
+    import_partial_guide(filePath, conf=conf, **kwargs)
 
 
 def build_from_file(filePath=None, conf=False, *args):


### PR DESCRIPTION
The function `import_guide_template` now accesses all keyword arguments of `import_partial_guide` function. 
![image](https://github.com/mgear-dev/mgear4/assets/11863299/55aef30d-2179-45b6-bd04-e5790b6ae241)

![image](https://github.com/mgear-dev/mgear4/assets/11863299/846b13d9-b501-48ef-af5a-b7518423f5fa)
