### PR TITLE
Fixed a bug in the behavior of the 'leg_boneCLenMult' attribute.

### DIFF
--- a/release/scripts/mgear/shifter_classic_components/leg_3jnt_01/__init__.py
+++ b/release/scripts/mgear/shifter_classic_components/leg_3jnt_01/__init__.py
@@ -531,7 +531,7 @@ class Component(component.Main):
         self.tws3_rot.setAttr("sx", 0.001)
 
         self.tws3_drv = primitive.addTransform(
-            self.legBones[2],
+            self.tws3_rot,
             self.getName("tws3_drv"),
             transform.getTransform(self.legBones[3]),
         )
@@ -1284,15 +1284,6 @@ class Component(component.Main):
             pm.connectAttr(self.volDriver_att, o_node + ".driver")
             pm.connectAttr(self.st_att[i], o_node + ".stretch")
             pm.connectAttr(self.sq_att[i], o_node + ".squash")
-
-        # connect roll rotation driver reference
-        pm.orientConstraint(
-            self.legBones[3],
-            self.tws3_drv,
-            skip=["y", "z"],
-            maintainOffset=True,
-            weight=1,
-        )
 
         # Visibilities -------------------------------------
         # fk


### PR DESCRIPTION
Reported in the forum. https://github.com/mgear-dev/mgear4/issues/379
http://forum.mgear-framework.com/t/quadruped-back-leg-leg-boneclenmult/3974


![leg_3jnt_01](https://github.com/mgear-dev/mgear4/assets/11863299/c86bf275-f343-40e9-a840-4771331541ed)

![leg_3jnt_01](https://github.com/mgear-dev/mgear4/assets/11863299/a492fb1d-87e3-4d24-9629-4e7d8732dc44)
