### PR TITLE
fix(sdk_io): float input to range

### DIFF
--- a/release/scripts/mgear/rigbits/sdk_io.py
+++ b/release/scripts/mgear/rigbits/sdk_io.py
@@ -414,7 +414,9 @@ def stripKeys(animNode):
     Args:
         animNode (pynode): sdk/anim node
     """
-    numKeys = len(pm.listAttr(animNode + ".ktv", multi=True)) / 3
+    numKeys = int(
+        len(pm.listAttr(animNode + ".ktv", multi=True)) / 3
+    )
     for x in range(0, numKeys):
         animNode.remove(0)
 

--- a/release/scripts/mgear/rigbits/sdk_io.py
+++ b/release/scripts/mgear/rigbits/sdk_io.py
@@ -414,9 +414,7 @@ def stripKeys(animNode):
     Args:
         animNode (pynode): sdk/anim node
     """
-    numKeys = int(
-        len(pm.listAttr(animNode + ".ktv", multi=True)) / 3
-    )
+    numKeys = len(pm.listAttr(animNode + ".ktv", multi=True)) // 3
     for x in range(0, numKeys):
         animNode.remove(0)
 


### PR DESCRIPTION
Fixed an error in `mgear.rigbits.sdk_io` when using Python3, where a float value was entered into range().