### PR TITLE
changed getShape to listRelatives

### DIFF
--- a/release/scripts/mgear/core/skin.py
+++ b/release/scripts/mgear/core/skin.py
@@ -89,7 +89,7 @@ def get_mesh_components_from_tag_expression(skinCls, tag="*"):
     for t in geo_types:
         obj = skinCls.listConnections(et=True, t=t)
         if obj:
-            geo = obj[0].getShape().name()
+            geo = pm.listRelatives(obj[0], s=True, ni=True)[0].name()
 
     # Get the geo out attribute for the shape
     out_attr = cmds.deformableShape(geo, localShapeOutAttr=True)[0]


### PR DESCRIPTION
## Description of Changes

Changed .getShape to listRelatives with the noIntermediate flag set to True to avoid issues arising from having multiple shapes. If you skin a referenced object the first shape becomes the "Orig" shape and not the skinned one.