### PR TITLE
Remove Redundant pm.parent Call in createGhostCtl to Fix Error with mgear.pymaya

### DIFF
--- a/release/scripts/mgear/rigbits/ghost.py
+++ b/release/scripts/mgear/rigbits/ghost.py
@@ -69,7 +69,6 @@ def createGhostCtl(ctl, parent=None, connect=True):
     for shape in source2.getShapes():
         pm.parent(shape, newCtl, r=True, s=True)
         pm.rename(shape, newCtl.name() + "Shape")
-        pm.parent(shape, newCtl, r=True, s=True)
     pm.delete(source2)
     if parent:
         pm.parent(newCtl, parent)


### PR DESCRIPTION
## Description of Changes

This PR removes an unnecessary pm.parent(shape, newCtl, r=True, s=True) call in the createGhostCtl function. Previously, importing pymel.core as pm masked the issue because there was no error, but switching to import mgear.pymaya as pm causes an error on this redundant parent call. Since the second pm.parent is not needed, it has been removed for clarity and compatibility.

## Testing Done

Confirmed that removing the redundant call does not affect the final hierarchy or shape assignment.

## Related Issue(s)

Please link the related issues.



