### PR TITLE
Fix pymel implicit conversion into explicitly retrieve name in pymaya

### DIFF
--- a/release/scripts/mgear/rigbits/__init__.py
+++ b/release/scripts/mgear/rigbits/__init__.py
@@ -27,7 +27,7 @@ def addNPO(objs=None, *args):
     for obj in objs:
         oParent = obj.getParent()
         oTra = pm.createNode(
-            "transform", n=obj.name() + "_npo", p=oParent, ss=True
+            "transform", n=obj.name() + "_npo", p=oParent.name(), ss=True
         )
         oTra.setTransformation(obj.getMatrix())
         pm.parent(obj, oTra)

--- a/release/scripts/mgear/shifter/component/guide.py
+++ b/release/scripts/mgear/shifter/component/guide.py
@@ -911,7 +911,7 @@ class ComponentGuide(guide.Main):
         pm.select(children)
         for child in pm.ls(self.fullName + "_*", selection=True):
             objects[
-                child[child.index(self.fullName + "_") + len(self.fullName + "_") :]
+                child.shortName()[child.index(self.fullName + "_") + len(self.fullName + "_") :]
             ] = child
 
         return objects


### PR DESCRIPTION
## Description of Changes

- Updated code to explicitly retrieve node names in pymaya.
- PyMaya does not provide implicit name conversion, so the naming logic must be explicitly handled in pymaya.

## Testing Done

Applied changes in a local Maya environment and verified that nodes are named correctly without errors.


