### PR TITLE
Fixed missing "size" on Guide file builds

### DIFF
--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -642,6 +642,9 @@ class Rig(Main):
                 p_local_name = c_dict["parent_localName"]
                 self.components[comp].parentLocalName = p_local_name
 
+        # More option values
+        self.addOptionsValues()
+
     def get_guide_template_dict(self, meta=None):
         """Get the guide temaplate configuration dictionary
 


### PR DESCRIPTION
## Description of Changes

When building a guide from a hierarchy after the components have been created there is a call to the `addOptionsValues` that generate the "size" option key value pair. This key value pair does not get generated anywhere else in the codebase.

So I added it to the `set_from_dict` that gets called from the build_from_file.

## Testing Done

Built some guides using there `.gst` files and the error no longer persisted and it looks like the builds completed correctly.

## Related Issue(s)

#485 



