### PR TITLE
Unreal Camera Import Post Process

### DIFF
--- a/release/scripts/mgear/uegear/camera.py
+++ b/release/scripts/mgear/uegear/camera.py
@@ -1,0 +1,66 @@
+import maya.cmds as cmds
+
+def mm_to_inches(mm_value):
+    """
+    Converts the mm value to an Inch value
+
+    mm_value
+        Millimeter value that will be converted into Inches
+    """
+    return mm_value / 25.4
+
+
+def has_filmback_attribute(obj_name):
+    """
+    Checks if the object (Usually a camera) has any film back attributes added to it.
+    """
+    attributes = cmds.listAttr(obj_name)
+
+    if any('Filmback' in name for name in attributes):
+        return True
+    return False
+
+def get_sensor_attributes(obj_name):
+    """Retrieves the Sensor / filmback attributes"""
+    sensor_names = ("SensorHeight", "SensorWidth")
+    found_attributes = [None, None]
+
+    for attribute_name in cmds.listAttr(obj_name):
+        for i, sensor_name in enumerate(sensor_names):
+            if sensor_name in attribute_name:
+                found_attributes[i] = attribute_name
+
+    return found_attributes
+
+
+def get_keys_for_attribute(obj_name, attribute):
+    """Gets the keyframe data for the specific attribute"""
+    full_attr = f"{obj_name}.{attribute}"
+    key_times = cmds.keyframe(full_attr, query=True, timeChange=True)
+    key_values = cmds.keyframe(full_attr, query=True, valueChange=True)
+    return key_times, key_values
+
+def apply_updated_keys(obj_name, attribute, key_times, updated_values):
+    """Adds keys to the specific attribute using the keys time and value arrays"""
+    full_attr = f"{obj_name}.{attribute}"
+    for time, value in zip(key_times, updated_values):
+        cmds.setKeyframe(full_attr, time=time, value=value)
+
+def unreal_to_maya_sensor_conversion(camera_name):
+    """
+    Converts an Unreal mm Film Back sensor into a Maya inch film apature value, and applies
+    it to the camera shape
+    """
+    sensor_exists = has_filmback_attribute(camera_name)
+
+    if sensor_exists:
+        sensor_names = get_sensor_attributes(camera_name)
+
+        for sensor_name in sensor_names:
+            frames, values = get_keys_for_attribute(camera_name, sensor_name)
+            values = [mm_to_inches(val) for val in values]
+
+            if 'Height' in sensor_name:
+                apply_updated_keys(camera_name, 'verticalFilmAperture', frames, values)
+            if 'Width' in sensor_name:
+                apply_updated_keys(camera_name, 'horizontalFilmAperture', frames, values)

--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -21,6 +21,7 @@ from mgear.core import attribute
 
 from mgear.uegear import log, tag, bridge, io, ioutils
 from mgear.uegear import utils as ueUtils
+from mgear.uegear import camera as ueCamera
 
 # DEBUGGING
 import importlib
@@ -729,6 +730,12 @@ def import_selected_cameras_from_unreal():
                 tag.apply_tag(
                     transform_node, tag.TAG_ASSET_PATH_ATTR_NAME, asset_path
                 )
+
+        # Check if camera contains filmback attribute, if it does then we convert the curve data and apply it to the
+        # `Sensor Height` `Sensor Width`
+        # transform node is always a camera, as we are only importing a camera.
+        for camera_name in transform_nodes:
+            ueCamera.unreal_to_maya_sensor_conversion(camera_name)
 
     return True
 


### PR DESCRIPTION
If the sensor was animated then we convert it and apply it back onto the camera aperture

## Description of Changes

Added some post process import methods when the camera import from unreal is triggered.

## Testing Done

Executed the import camera command in Maya that imports the camera from Unreal

## Related Issue(s)

ueGear issue, no ticket was created



