### PR TITLE
Corrected shifter path

### DIFF
--- a/release/scripts/mgear/shifter/__init__.py
+++ b/release/scripts/mgear/shifter/__init__.py
@@ -112,7 +112,7 @@ def getComponentDirectories():
 def importComponentGuide(comp_type):
     """Import the Component guide"""
     dirs = getComponentDirectories()
-    defFmt = "mgear.core.shifter.component.{}.guide"
+    defFmt = "mgear.shifter.component.{}.guide"
     customFmt = "{}.guide"
 
     module = mgear.core.utils.importFromStandardOrCustomDirectories(
@@ -124,7 +124,7 @@ def importComponentGuide(comp_type):
 def importComponent(comp_type):
     """Import the Component"""
     dirs = getComponentDirectories()
-    defFmt = "mgear.core.shifter.component.{}"
+    defFmt = "mgear.shifter.component.{}"
     customFmt = "{}"
 
     module = mgear.core.utils.importFromStandardOrCustomDirectories(


### PR DESCRIPTION
## Description of Changes

The shifter path used the old path structure

## Testing Done

Ran test on Build system that was failing. After path modified guide building from file worked succesfully.

## Related Issue(s)

#492 



