### PR TITLE
Update mocap_tools.py : compatible with a wider definition and avoid breaking if skeleton not found.

### DIFF
--- a/release/scripts/mgear/shifter/mocap_tools.py
+++ b/release/scripts/mgear/shifter/mocap_tools.py
@@ -21,6 +21,8 @@ skelFK = [
         u"Spine",
         u"Spine1",
         u"Spine2",
+        u"Spine3",
+        u"Spine4",
         u"LeftShoulder",
         u"LeftArm",
         u"LeftForeArm",
@@ -61,6 +63,8 @@ skelFK = [
         u"RightHandPinky3",
         u"Neck",
         u"Neck1",
+        u"Neck2",
+        u"Neck3",
         u"Head"
     )
 ]
@@ -201,7 +205,8 @@ def characterizeBiped(*args):
             oB = pm.PyNode(b)
         except Exception:
             pm.displayWarning(b + ": Is not in the scene")
-        tra.matchWorldTransform(oB, oA)
+        if a and b:
+            tra.matchWorldTransform(oB, oA)
 
     # Constrain FK controls
     for a, b in zip(skelFK, gearFK):


### PR DESCRIPTION
This fix will help the mocap tool to build the control rig for a wider range of skeletons, and avoid breaking if some bones aren't found.

## Description of Changes
I added more bones inside the description in case the skeleton has more bones in the spine or the neck
and add a if statement in case those added bones aren't found in the current skeleton.

## Testing Done
Worked for me !

## Related Issue(s)
Initially, the mocap tool doesn't care if there is a Spine3 bone, and breaks if Neck1 isn't found (for exemple).


