### PR TITLE
Update guide_manager_component.py :  skip loading of __pycache__ modules

### DIFF
--- a/release/scripts/mgear/shifter/guide_manager_component.py
+++ b/release/scripts/mgear/shifter/guide_manager_component.py
@@ -90,7 +90,7 @@ class GuideManagerComponent(MayaQWidgetDockableMixin, QtWidgets.QDialog):
                 pm.progressWindow(
                     e=True, step=1, status="\nLoading: %s" % comp_name
                 )
-                if comp_name == "__init__.py":
+                if comp_name in ["__init__.py", "__pycache__"]:
                     continue
                 elif comp_name in trackLoadComponent:
                     pm.displayWarning(


### PR DESCRIPTION
Avoid the guide manager to show a warning when displayed

## Description of Changes
It adds an exception for __pycache__ files

## Testing Done
With this fix, I no more have this issue.

## Related Issue(s)
![image](https://github.com/user-attachments/assets/7c6e310f-60ff-4b41-8ecf-004742e0248e)
Guide Manager skip __init__.py messages but not __pycache__ folders so it raises a warning that __pycache__ is already in default components, names should be unique.


