### PR TITLE
[ueGear] Object Path validation for 5.5+

### DIFF
--- a/release/scripts/mgear/uegear/bridge.py
+++ b/release/scripts/mgear/uegear/bridge.py
@@ -48,6 +48,25 @@ class UeGearBridge(object):
             "Accept": "text/plain",
         }
 
+        self.pre_run()
+
+    def pre_run(self):
+        """
+        A pre run check that will try to retrieve the Engine version, if it fails it will change the object path.
+
+        This is due to UE 5.5 handling python packages differently.
+        """
+        result = self.execute("get_unreal_version").get("ReturnValue", "")
+        if result:
+            print(f"[UEGear Remote Session] {result}")
+        else:
+            print(f"[UEGear Remote Session] Pre run failed, changing Object Path to 5.5+ structure")
+            self._commands_object_path = "/ueGear/Python/ueGear/commands_PY.Default__PyUeGearCommands"
+
+            result = self.execute("get_unreal_version").get("ReturnValue", "")
+            if result:
+                print(f"[UEGear Remote Session] {result}")
+
     # =================================================================================================================
     # PROPERTIES
     # =================================================================================================================

--- a/release/scripts/mgear/uegear/commands.py
+++ b/release/scripts/mgear/uegear/commands.py
@@ -32,6 +32,17 @@ importlib.reload(ueUtils)
 
 logger = log.uegear_logger
 
+def get_unreal_version():
+    """Gets the Unreal version for the active session"""
+    print("[mGear] Retrieving Unreal Engine Version.")
+
+    uegear_bridge = bridge.UeGearBridge()
+
+    result = uegear_bridge.execute(
+        "get_unreal_version"
+    ).get("ReturnValue", "")
+
+    return result
 
 def content_project_directory():
     """


### PR DESCRIPTION
## Description of Changes

in 5.5+ the object path required for the rest body need to be different from 5.4-

## Testing Done

Used the Export Game tool and all commands were populating correctly in 5.3 and 5.5

## Related Issue(s)

[Please link the related issues.](https://github.com/mgear-dev/ueGear/issues/54)



