### PR TITLE
Allow underscores in `rig_name` property. 

### DIFF
--- a/release/scripts/mgear/core/curve.py
+++ b/release/scripts/mgear/core/curve.py
@@ -64,10 +64,11 @@ def addCurve(
     Arguments:
         parent (dagNode): Parent object.
         name (str): Name
-        points (list of float): points of the curve in a one dimension array
+        points (list of float | list of datatypes.Vector | list of om2.MPoint):
+            points of the curve in a one dimension array
             [point0X, point0Y, point0Z, 1, point1X, point1Y, point1Z, 1, ...].
         close (bool): True to close the curve.
-        degree (bool): 1 for linear curve, 3 for Cubic.
+        degree (int): 1 for linear curve, 3 for Cubic.
         m (matrix): Global transform.
         op (bool, optional): If True will add a curve that pass over the points
                             This is equivalent of using"editPoint " flag

--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -1851,7 +1851,7 @@ class GuideSettings(MayaQWidgetDockableMixin, GuideMainSettings):
         # Setting Tab
         tap = self.guideSettingsTab
         tap.rigName_lineEdit.editingFinished.connect(
-            partial(self.updateLineEdit, tap.rigName_lineEdit, "rig_name")
+            partial(self.updateLineEdit2, tap.rigName_lineEdit, "rig_name")
         )
         tap.mode_comboBox.currentIndexChanged.connect(
             partial(self.updateComboBox, tap.mode_comboBox, "mode")


### PR DESCRIPTION
## Description of Changes

Please clearly state what you have changed and why you made these changes.

Allow underscores in `rig_name` property. 
Main guide settings tab now uses the `updateLineEdit2` method, which ensures Maya-compatible names.
This PR is because mGear currently prohibits the use of the underscore character when trying to specify a name for the rig root, which is a very common delimiter. It is *possible* to bypass this by editing the attributes directly; but having it accessible to users in an official capacity via the GUI is preferred.

There is another commit: some minor fixes to incorrect type hints without introducing new imports.

## Testing Done

Please describe the tests that you ran to verify your changes.

Tested with:
* Maya 2026
* mGear 5.0.7
* EPIC Mannequin Template, Y-up

Able to build a rig with rig root named "my_rig_root_with_underscores".
Custom step instance's `.mgear_run.model` property returns "my_rig_root_with_underscores" as expected.
Guide template "EPIC Mannequin Template, Y-up" seems to build correctly.
Have not tested with other tools in suite.

## Related Issue(s)

Please link the related issues.
 N/A.


