### PR TITLE
Remove blank undescore with _{side} and side naming is empty.

### DIFF
--- a/release/scripts/mgear/shifter/component/__init__.py
+++ b/release/scripts/mgear/shifter/component/__init__.py
@@ -1004,6 +1004,9 @@ class Main(object):
             letter_case=self.options["ctl_description_letter_case"],
         )
 
+        if fullName.endswith("_"):
+            fullName = fullName[:-1]
+
         bufferName = fullName + "_controlBuffer"
         if bufferName in self.rig.guide.controllers.keys():
             ctl_ref = self.rig.guide.controllers[bufferName]


### PR DESCRIPTION
Avoid ending a object name with an underscore

## Description of Changes
When using a naming convention like this : 
<img width="532" height="491" alt="image" src="https://github.com/user-attachments/assets/47858094-e990-44fc-ab27-23429d179a57" />

and with _{side} at end of joints or controls naming rule, objects may ends with a blank underscore with nothing behind. The fix could avoid this behavior. 
I assume this naming convention isn't very conventional, but in order to make mGear more robust with more situations, i thought it could be nice to suggest it.

## Testing Done

## Related Issue(s)
<img width="276" height="214" alt="image" src="https://github.com/user-attachments/assets/a02b398a-6344-4b86-a913-eee797bd9e75" />
<img width="193" height="54" alt="image" src="https://github.com/user-attachments/assets/384670c9-0491-45b5-a8f4-8a31787353ff" />



