### PR TITLE
fix an error when generating diamond icon with pos offset

### DIFF
--- a/release/scripts/mgear/core/icon.py
+++ b/release/scripts/mgear/core/icon.py
@@ -635,7 +635,7 @@ def diamond(
     pN = datatypes.Vector(dlen, 0, dlen * -1)
     Np = datatypes.Vector(dlen * -1, 0, dlen)
     NN = datatypes.Vector(dlen * -1, 0, dlen * -1)
-    bottom = (0, -dlen, 0)
+    bottom = datatypes.Vector(0, -dlen, 0)
 
     v_array = [
         pp,


### PR DESCRIPTION
## Description of Changes

I changed the "bottom" variable in diamond() (mgear/core/icon.py) from a tuple to a maya vector.
Since "bottom" was not maya vector, the addition "bottom + pos_offset" failed in getPointArrayWithOffset function.

## Testing Done

I checked the diamond icon can be successfully generated  in a custom component by addCtl function with a position offset.

## Related Issue(s)

no related issue


