### PR TITLE
[533] Lip Autoskin not working

### DIFF
--- a/release/scripts/mgear/rigbits/facial_rigger/lips_rigger.py
+++ b/release/scripts/mgear/rigbits/facial_rigger/lips_rigger.py
@@ -784,7 +784,7 @@ def rig(edge_loop="",
 
         skinCluster = skin.getSkinCluster(objName)
         if not skinCluster:
-            skinCluster = pm.skinCluster(head_joint,
+            [skinCluster] = pm.skinCluster(head_joint,
                                          geo,
                                          tsb=True,
                                          nw=2,


### PR DESCRIPTION

## Description of Changes

Unpacks the result of pm.skinCluster to get the skincluster node instead of a list.

## Testing Done

Tested lip rigger in a freshly built character. 

## Related Issue(s)

Issue #533



