### PR TITLE
[529] Changes rotate order value on readerB to improve stability on knee auto thickness

### DIFF
--- a/release/scripts/mgear/shifter_classic_components/leg_2jnt_02/__init__.py
+++ b/release/scripts/mgear/shifter_classic_components/leg_2jnt_02/__init__.py
@@ -413,7 +413,7 @@ class Component(component.Main):
         self.readerB = primitive.addTransform(
             self.readerA, self.getName("readerB_loc"), t
         )
-        self.readerB.rotateOrder.set(2)
+        self.readerB.rotateOrder.set(3)
 
         # Divisions ----------------------------------------
         # We have at least one division at the start, the end and one for


### PR DESCRIPTION
## Description of Changes

Rotation value on readerB was being used to drive the autothickness displacement, however, readerB was constrained to leg_R1_1_bone and they both have different orientations, making the rotation values pop at times. Changing the rotate order from 'zxy' to 'xzy' appears to be more stable. 

## Testing Done

Moved the leg to different poses to test stability. 

## Related Issue(s)

#529 


