### PR TITLE
Fix Broken Anim Picker on Linux

### DIFF
--- a/release/scripts/mgear/anim_picker/widgets/picker_widgets.py
+++ b/release/scripts/mgear/anim_picker/widgets/picker_widgets.py
@@ -1486,10 +1486,7 @@ class PointHandle(DefaultPolygon):
 
     def paint(self, painter, options, widget=None):
         """Paint graphic item"""
-        if basic.__USE_OPENGL__:
-            painter.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
-        else:
-            painter.setRenderHint(QtGui.QPainter.Antialiasing)
+        painter.setRenderHint(QtGui.QPainter.Antialiasing)
 
         # Get polygon path
         path = self.shape()
@@ -1597,10 +1594,7 @@ class Polygon(DefaultPolygon):
     def paint(self, painter, options, widget=None):
         """Paint graphic item"""
         # Set render quality
-        if basic.__USE_OPENGL__:
-            painter.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
-        else:
-            painter.setRenderHint(QtGui.QPainter.Antialiasing)
+        painter.setRenderHint(QtGui.QPainter.Antialiasing)
 
         # Get polygon path
         path = self.shape()
@@ -1826,10 +1820,7 @@ class PickerItem(DefaultPolygon):
         pass
         # for debug only
         # # Set render quality
-        # if basic.__USE_OPENGL__:
-        #    painter.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
-        # else:
-        #    painter.setRenderHint(QtGui.QPainter.Antialiasing)
+        # painter.setRenderHint(QtGui.QPainter.Antialiasing)
 
         # # Get polygon path
         # path = self.shape()


### PR DESCRIPTION
## Description of Changes
This changes the anti-aliasing settings for the anim picker widgets so that they don't error when using pyside6. (eg Maya 2026 on Linux)
The lines changed here are straight from https://github.com/mgear-dev/mgear/issues/580 . I don't pretend to have been the one to figure this out, but am just submitting this as a convenience to make it easy to merge in hopes this gets fixed soon :)
## Testing Done
Tested on Maya 2026 on RHEL 9 and Windows 11. I don't have the ability to test on versions of Maya <2025 when Maya switched to pyside6, so would love if someone could test.

## Related Issue(s)
https://github.com/mgear-dev/mgear/issues/580

