### PR TITLE
Fix replace shape

### DIFF
--- a/release/scripts/mgear/rigbits/__init__.py
+++ b/release/scripts/mgear/rigbits/__init__.py
@@ -412,19 +412,33 @@ def replaceShape(source=None, targets=None, *args):
         shape = target.getShapes()
         cnx = []
         if shape:
-            cnx = shape[0].listConnections(plugs=True, c=True)
-            cnx = [[c[1], c[0].shortName()] for c in cnx]
+            raw_cnx = shape[0].listConnections(plugs=True, c=True)
+            # Store (is_destination, other_plug, shape_attr_short_name)
+            # so we can restore the correct connection direction later.
+            cnx = [
+                [c[0].plug().isDestination, c[1], c[0].shortName()]
+                for c in raw_cnx
+            ]
             # Disconnect the conexion before delete the old shape
             for s in shape:
                 for c in s.listConnections(plugs=True, c=True):
-                    pm.disconnectAttr(c[0])
+                    if c[0].plug().isDestination:
+                        pm.disconnectAttr(c[1], c[0])
+                    else:
+                        pm.disconnectAttr(c[0], c[1])
         pm.delete(shape)
         pm.parent(source2.getShapes(), target, r=True, s=True)
 
         for i, sh in enumerate(target.getShapes()):
-            # Restore shapes connections
-            for c in cnx:
-                pm.connectAttr(c[0], sh.attr(c[1]))
+            # Restore shapes connections respecting original direction.
+            for is_dst, other_plug, shape_attr in cnx:
+                try:
+                    if is_dst:
+                        pm.connectAttr(other_plug, sh.attr(shape_attr))
+                    else:
+                        pm.connectAttr(sh.attr(shape_attr), other_plug)
+                except RuntimeError:
+                    pass
             pm.rename(sh, target.name() + "_%s_Shape" % str(i))
 
         pm.delete(source2)


### PR DESCRIPTION
## Description of Changes

Fixing `replaceShape` for the error below:

```
# Traceback (most recent call last):
#   File "scripts\mgear\pymaya\cmd.py", line 254, in wrapper
#     res = func(*args, **kwargs)
# RuntimeError: The attribute 'MayaNodeEditorSavedTabsInfo.tabGraphInfo[0].nodeInfo[209].dependNode' cannot be connected to 'fin_R0_ctl2Shape.message'.
# 
# # 
# The above exception was the direct cause of the following exception:

# Traceback (most recent call last):
#   File "scripts\mgear\rigbits\mirror_controls.py", line 173, in mirror_button_pressed
#     self.func.mirror_right_to_left()
#   File "scripts\mgear\rigbits\mirror_controls.py", line 131, in mirror_right_to_left
#     self.mirror_pairs(pairs)
#   File "scripts\mgear\rigbits\mirror_controls.py", line 99, in mirror_pairs
#     mgear.rigbits.replaceShape(source_copy, [target])
#   File "scripts\mgear\rigbits\__init__.py", line 427, in replaceShape
#     pm.connectAttr(c[0], sh.attr(c[1]))
#   File "scripts\mgear\pymaya\cmd.py", line 266, in wrapper
#     raise RuntimeError(
# RuntimeError: # Error occurred while calling wrapped function 'maya.cmds.connectAttr': The attribute 'MayaNodeEditorSavedTabsInfo.tabGraphInfo[0].nodeInfo[209].dependNode' cannot be connected to 'fin_R0_ctl2Shape.message'.
# 
# Arguments: ('MayaNodeEditorSavedTabsInfo.tabGraphInfo[0].nodeInfo[209].dependNode', 'fin_R0_ctl2Shape.message')
# Keyword Arguments: {}
Command for debugging: maya.cmds.connectAttr('MayaNodeEditorSavedTabsInfo.tabGraphInfo[0].nodeInfo[209].dependNode', 'fin_R0_ctl2Shape.message', )
```

## Testing Done

Use the `mgear > Rigbits > Mirror Control Shapes` tool, using "Right to Left" option.



