### PR TITLE
Raise error if FCurve param def is missing `get_divisions`

### DIFF
--- a/release/scripts/mgear/shifter/component/guide.py
+++ b/release/scripts/mgear/shifter/component/guide.py
@@ -274,14 +274,18 @@ class ComponentGuide(guide.Main):
         return
 
     def get_divisions(self):
-        """Get the divisions to sample a Fcurve parameter definition.
+        """Get the divisions to sample a FCurve parameter definition.
 
         Note:
-            REIMPLEMENT. This method should only if the component is using
-            Fcurve paramDef.
+            REIMPLEMENT. This method must be implemented if the component is using an
+            FCurve paramDef.
 
         """
-        return
+        errmsg = (
+            f"'{self.compType}' has FCurve parameters but is missing a required "
+            f"`get_divisions` implementation in the `Guide` class."
+        )
+        raise NotImplementedError(errmsg)
 
     def getMergedValues(self):
         """Get merged component values combining local with blueprint settings.


### PR DESCRIPTION
## Description of Changes

Update `ComponentGuide.get_divisions` to raise a `NotImplementedError` with a clearer error message. 
This happens when a component has an FCurve param def, but does not implement `get_divisions`.

Compared to the current behavior, which is a generic error message (`TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'`), this better points towards the source of the problem.

Want to also point out: `get_divisions` is only called in the `shifter.guide` **base** class, but not implemented, while it is only implemented in the `shifter.component.guide` **sub**class, but never called, adding to the unclarity when tracing through.

## Testing Done

Maya 2027
mGear 5.3.3

Able to successfully build "EPIC_mannequin_y_up" template.

## Related Issue(s)

N/A
