### PR TITLE
Add proxying to `addAnimParam`

### DIFF
--- a/release/scripts/mgear/core/attribute.py
+++ b/release/scripts/mgear/core/attribute.py
@@ -323,8 +323,8 @@ def addEnumAttribute(
 
 
 def addProxyAttribute(sourceAttrs, targets, duplicatedPolicy=None):
-    """Add proxy paramenter to a list of target dagNode
-    Duplicated channel policy, stablish the rule in case the channel already
+    """Add proxy parameter to a list of target dagNode
+    Duplicated channel policy, establish the rule in case the channel already
     exist on the target.
 
     Duplicate policy options
@@ -341,7 +341,7 @@ def addProxyAttribute(sourceAttrs, targets, duplicatedPolicy=None):
         sourceAttrs (attr or list of attr): The parameters to be connected as
             proxy
         targets (dagNode or list of dagNode): The list of dagNode to add the
-            proxy paramenter
+            proxy parameter
         duplicatedPolicy (string, optional): Set the duplicated channel policy
     """
     if not isinstance(targets, list):

--- a/release/scripts/mgear/shifter/component/__init__.py
+++ b/release/scripts/mgear/shifter/component/__init__.py
@@ -1360,6 +1360,7 @@ class Main(object):
         writable=True,
         uihost=None,
         exactName=False,
+        proxyNodes=None,
     ):
         """Add a parameter to the animation property.
 
@@ -1379,6 +1380,8 @@ class Main(object):
             uihost (dagNode): Optional uihost, if none self.uihost will be use
             exactName (bool): if true will use the attr name without prefix
                             from the component name or instance name.(optional)
+            proxyNodes (pm.node._Node or list of pm.node._Node): Add proxy attributes
+                to these nodes. (optional)
 
         Returns:
             pm.Attribute: A pymaya `Attribute` wrapper of the new attribute.
@@ -1426,6 +1429,10 @@ class Main(object):
                     writable=writable,
                 )
 
+        proxyNodes = proxyNodes or []
+        if self.validProxyChannels and proxyNodes:
+            attribute.addProxyAttribute(attr, proxyNodes)
+
         return attr
 
     # Add a parameter to the animation property.\n
@@ -1443,6 +1450,7 @@ class Main(object):
         writable=True,
         uihost=None,
         exactName=False,
+        proxyNodes=None,
     ):
         """Add a parameter to the animation property.
 
@@ -1459,6 +1467,8 @@ class Main(object):
             storable (bool): Set if the attribute is storable or not.(optional)
             writable (bool): Set if the attribute is writable or not.(optional)
             uihost (dagNode): Optional uihost, if none self.uihost will be use
+            proxyNodes (pm.node._Node or list of pm.node._Node): Add proxy attributes
+                to these nodes. (optional)
 
         Returns:
             str: The long name of the new attribute
@@ -1502,6 +1512,10 @@ class Main(object):
                     storable=storable,
                     writable=writable,
                 )
+
+        proxyNodes = proxyNodes or []
+        if self.validProxyChannels and proxyNodes:
+            attribute.addProxyAttribute(attr, proxyNodes)
 
         return attr
 


### PR DESCRIPTION
## Description of Changes

Add a new `proxyNodes=None` parameter to comp rigs' `.addAnimParam` and `.addAnimEnumParam` methods.

The current pattern is to "track all attributes and then add proxies later". 
This provides an alternative where proxies can be added in the same call, not having to manage attributes/proxy in two places.

## Testing Done

Maya 2026
mGear 5.3.3

Able to build/rebuild "EPIC_mannequin_y_up" template without error.
Able to build/rebuild custom components that are using the new parameter, and proxy attributes are added where expected.

## Related Issue(s)

N/A
