### PR TITLE
Change joint object reference in EPIC_arm_02

### DIFF
--- a/release/scripts/mgear/shifter_epic_components/EPIC_arm_02/__init__.py
+++ b/release/scripts/mgear/shifter_epic_components/EPIC_arm_02/__init__.py
@@ -685,7 +685,7 @@ class Component(component.Main):
                 if self.settings["div0"]:
                     self.jnt_pos.append(
                         {
-                            "obj": roll_off,
+                            "obj": self.arm_root_base,
                             "name": jdn_upperarm + "_swing",
                             "data_contracts": "Twist,Squash",
                             "newActiveJnt": current_parent,


### PR DESCRIPTION

## Description of Changes

I changed from roll_off to self.arm_root_base in self.jnt_pos for the swing_jnt.

## Testing Done
Before :
<img width="1988" height="659" alt="image" src="https://github.com/user-attachments/assets/3e476cf5-8d5b-4874-b24f-a6a14a1b776e" />

After :
<img width="2003" height="605" alt="image" src="https://github.com/user-attachments/assets/7f7f7b38-ab69-4796-be9b-77d47e858da0" />

## Related Issue(s)

The issue was that swing_jnt wasn't mirrored properly, due to the referenced obj in the dict from self.jnt_pos.

Repro steps of the initial issue : 
1. Create Epic_arm_02
2. Set it to “Left”
3. Mirror the guide
4. Build the rig

[http://forum.mgear-framework.com/t/new-swing-joint-for-epic-arm-02-isnt-mirrored/5312](http://forum.mgear-framework.com/t/new-swing-joint-for-epic-arm-02-isnt-mirrored/5312
)



