### PR TITLE
Shifter: Guide Explorer: Fix selection sync error on component selection

### DIFF
--- a/release/scripts/mgear/shifter/guide_explorer/guide_tree_widget.py
+++ b/release/scripts/mgear/shifter/guide_explorer/guide_tree_widget.py
@@ -722,11 +722,17 @@ class GuideTreeWidget(QtWidgets.QTreeWidget):
             return
 
         selection = shifter_utils.get_selection()
-        if not selection:
+
+        # -- Filter out component selections
+        dag_selection = []
+        for item in selection:
+            if hasattr(item, "isDag") and item.isDag():
+                dag_selection.append(item)
+        if not dag_selection:
             return
 
         # -- Take the last selected object
-        last_item = selection[-1]
+        last_item = dag_selection[-1]
 
         # -- Try to find the component root for this object
         comp_root = shifter_utils.find_component_root(last_item)


### PR DESCRIPTION
## Description of Changes

Fixes an error in Guide Explorer when **Sync Selection** is enabled and the Maya selection includes components (vertices, nurbsCVs etc. ).

With selection sync on, `_on_scene_selection_changed` passes the current Maya selection to `find_component_root()`. When the last selected item is a component (e.g. `MeshVertex`), `find_component_root()` calls `hasAttr()` on an object that does not support it, raising: `AttributeError: 'MeshVertex' object has no attribute 'hasAttr' `

Filtered the selection to DAG objects only.
Changes are limited to `guide_tree_widget.py`.

## Testing Done

Maya 2027
mGear 5.3.3

## Related Issue(s)

N/A

thank you.

